### PR TITLE
Make source app bundle identifier optional

### DIFF
--- a/Finicky/Finicky/AppDelegate.swift
+++ b/Finicky/Finicky/AppDelegate.swift
@@ -64,7 +64,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let pid = event!.attributeDescriptorForKeyword(AEKeyword(keySenderPIDAttr))!.int32Value
         let sourceBundleIdentifier = NSRunningApplication(processIdentifier: pid)?.bundleIdentifier
 
-        let callback = callUrlHandlers(sourceBundleIdentifier!)
+        let callback = callUrlHandlers(sourceBundleIdentifier)
 
         if shortUrlResolver.isShortUrl(url) {
             shortUrlResolver.resolveUrl(url, callback: callback)
@@ -73,7 +73,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
-    func callUrlHandlers(sourceBundleIdentifier: String)(url: NSURL) {
+    func callUrlHandlers(sourceBundleIdentifier: String?)(url: NSURL) {
         let flags = getFlags()
         var bundleIdentifier : String! = AppDelegate.defaultBrowser
         var newUrl : NSURL = url

--- a/Finicky/Finicky/FNAPI.swift
+++ b/Finicky/Finicky/FNAPI.swift
@@ -18,6 +18,7 @@ import JavaScriptCore
 @objc class FinickyAPI : NSObject, FinickyAPIExports {
 
     private static var urlHandlers = Array<JSValue>()
+    private static var context : JSContext! = nil
 
     class func setDefaultBrowser(browser: String?) -> Void {
         AppDelegate.defaultBrowser = browser
@@ -36,6 +37,10 @@ import JavaScriptCore
     class func reset() -> Void {
         urlHandlers.removeAll(keepCapacity: true)
     }
+    
+    class func setContext(context: JSContext) {
+        self.context = context
+    }
 
     /**
         Get strategy from registered handlers
@@ -48,14 +53,21 @@ import JavaScriptCore
             the new url and bundle identifier to spawn
     */
 
-    class func callUrlHandlers(originalUrl: NSURL, sourceBundleIdentifier: String, flags : Dictionary<String, Bool>) -> Dictionary<String, String> {
+    class func callUrlHandlers(originalUrl: NSURL, sourceBundleIdentifier: String?, flags : Dictionary<String, Bool>) -> Dictionary<String, String> {
         var strategy : Dictionary<String, String> = [
             "url": originalUrl.absoluteString!,
             "bundleIdentifier": ""
         ]
-
+        
+        var sourceBundleId : AnyObject
+        if sourceBundleIdentifier != nil {
+            sourceBundleId = sourceBundleIdentifier!
+        } else {
+            sourceBundleId = JSValue(nullInContext: context)
+        }
+    
         var options : Dictionary<String, AnyObject> = [
-            "sourceBundleIdentifier": sourceBundleIdentifier,
+            "sourceBundleIdentifier": sourceBundleId,
             "flags": flags
         ]
 

--- a/Finicky/Finicky/FNConfigLoader.swift
+++ b/Finicky/Finicky/FNConfigLoader.swift
@@ -64,6 +64,7 @@ class FNConfigLoader {
     }
 
     func setupAPI(ctx: JSContext) {
+        FinickyAPI.setContext(ctx)
         ctx.setObject(FinickyAPI.self, forKeyedSubscript: "api")
         ctx.setObject(FinickyAPI.self, forKeyedSubscript: "finicky")
     }


### PR DESCRIPTION
Fixes #12 

Makes the source app bundle identifier optional all the way through to the API call.