### PR TITLE
Add currently selected strategy as a parameter to URL handlers

### DIFF
--- a/Finicky/Finicky/FNAPI.swift
+++ b/Finicky/Finicky/FNAPI.swift
@@ -55,8 +55,7 @@ import JavaScriptCore
 
     public class func callUrlHandlers(originalUrl: NSURL, sourceBundleIdentifier: String?, flags : Dictionary<String, Bool>) -> Dictionary<String, AnyObject> {
         var strategy : Dictionary<String, AnyObject> = [
-            "url": originalUrl.absoluteString!,
-            "bundleIdentifier": ""
+            "url": originalUrl.absoluteString!
         ]
         
         var sourceBundleId : AnyObject
@@ -71,9 +70,10 @@ import JavaScriptCore
             "flags": flags
         ]
 
+        var previousStrategy : [NSObject : AnyObject]! = strategy
         for handler in urlHandlers {
             let url = strategy["url"]! as! String
-            let val = handler.callWithArguments([url, options])
+            let val = handler.callWithArguments([url, options, previousStrategy])
 
             if !val.isUndefined() {
                 let handlerStrategy = val.toDictionary()
@@ -94,6 +94,7 @@ import JavaScriptCore
                         break
                     }
                 }
+                previousStrategy = strategy
             }
         }
         return strategy


### PR DESCRIPTION
Adds a new parameter to onUrl handler which contains the current strategy. Might be useful for someone.

Fixes #15 