### PR TITLE
Add ability to open local html documents

### DIFF
--- a/Finicky/Finicky/AppDelegate.swift
+++ b/Finicky/Finicky/AppDelegate.swift
@@ -127,6 +127,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             "alt": NSEvent.modifierFlags() & .AlternateKeyMask != nil
         ]
     }
+    
+    func application(sender: NSApplication, openFiles filenames: [AnyObject]) {
+        for filename in filenames {
+            callUrlHandlers(nil)(url: NSURL(fileURLWithPath: filename as! String)!)
+        }
+    }
 
     func applicationWillFinishLaunching(aNotification: NSNotification) {
         configLoader = FNConfigLoader()

--- a/Finicky/Finicky/Info.plist
+++ b/Finicky/Finicky/Info.plist
@@ -4,6 +4,29 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>html</string>
+			</array>
+			<key>CFBundleTypeIconFile</key>
+			<string>finicky</string>
+			<key>CFBundleTypeMIMETypes</key>
+			<array>
+				<string>text/html</string>
+			</array>
+			<key>CFBundleTypeName</key>
+			<string>HTML Document</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSTypeIsPackage</key>
+			<integer>0</integer>
+			<key>NSDocumentClass</key>
+			<string>NSDocument</string>
+		</dict>
+	</array>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIconFile</key>


### PR DESCRIPTION
Fixes #18 

Add ability to open local html documents. File path is converted to an URL and then run through the normal handlers.