### PR TITLE
Supply an array of bundle identifiers

### DIFF
--- a/Finicky/Finicky/FNAPI.swift
+++ b/Finicky/Finicky/FNAPI.swift
@@ -82,8 +82,9 @@ import JavaScriptCore
                         strategy["url"] = (handlerStrategy["url"] as! String)
                     }
 
-                    if handlerStrategy["bundleIdentifier"] != nil {
-                        strategy["bundleIdentifier"] = (handlerStrategy["bundleIdentifier"] as! String)
+                    let bundleId: AnyObject? = handlerStrategy["bundleIdentifier"]
+                    if bundleId != nil {
+                        strategy["bundleIdentifier"] = bundleId!
                     }
                     
                     if handlerStrategy["openInBackground"] != nil {

--- a/README.md
+++ b/README.md
@@ -82,4 +82,13 @@ finicky.onUrl(function(url, opts) {
 	}
 });
 
+// By supplying an array of bundle identifiers, finicky opens the url in the first one
+// that's currently running. If none are running, the first app in the array is started.
+finicky.onUrl(function(url, opts) {
+	return {
+		bundleIdentifier: ['org.mozilla.firefox', 'com.apple.Safari', 'com.google.Chrome']
+	}
+});
+
+
 ```


### PR DESCRIPTION
Allow finicky to start the preferred browser for any link. For example, you might want only want Chrome to open a certain url if Chrome is already running, and use Safari if not.

Fixes #21 