### PR TITLE
#40 : Support for Google Chrome Profile 

### DIFF
--- a/Finicky/Finicky/AppDelegate.swift
+++ b/Finicky/Finicky/AppDelegate.swift
@@ -210,7 +210,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
         if let appDescriptor = configLoader.determineOpeningApp(url: url, sourceBundleIdentifier: sourceBundleIdentifier, sourceProcessPath: sourceProcessPath) {
             if let appToStart = getActiveApp(browsers: appDescriptor.browsers) {
                 if NSWorkspace.shared.absolutePathForApplication(withBundleIdentifier: appToStart.bundleId) != nil {
-                    openUrlWithBrowser(appDescriptor.url, bundleIdentifier: appToStart.bundleId, openInBackground: appToStart.openInBackground)
+                    openUrlWithBrowser(appDescriptor.url, bundleIdentifier: appToStart.bundleId, profileName:appToStart.profileName, openInBackground: appToStart.openInBackground)
                 } else {
                     let description = "Finicky was unable to find the application \"" + appToStart.name + "\""
                     print(description)
@@ -229,10 +229,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
         showTestConfigWindow(nil)
     }
 
-    func openUrlWithBrowser(_ url: URL, bundleIdentifier: String, openInBackground: Bool?) {        
+    func openUrlWithBrowser(_ url: URL, bundleIdentifier: String, profileName:String,  openInBackground: Bool?) {
         let openInBackground = openInBackground ?? false
         print("Opening " + bundleIdentifier + " at: " + url.absoluteString)
-        let command = getBrowserCommand(bundleIdentifier, url: url, openInBackground: openInBackground)
+        let command = getBrowserCommand(bundleIdentifier, profileName:profileName, url: url, openInBackground: openInBackground)
         shell(command)
     }
 

--- a/Finicky/Finicky/AppDescriptor.swift
+++ b/Finicky/Finicky/AppDescriptor.swift
@@ -15,10 +15,12 @@ public struct BrowserOpts {
     public var name: String
     public var openInBackground: Bool?
     public var bundleId: String
+    public var profileName:String
 
-    public init(name: String, appType: AppDescriptorType, openInBackground: Bool?) throws {
+    public init(name: String, appType: AppDescriptorType, openInBackground: Bool?, profileName: String) throws {
         self.name = name
         self.openInBackground = openInBackground
+        self.profileName = profileName
 
         if appType == AppDescriptorType.bundleId {
             bundleId = name

--- a/Finicky/Finicky/Browsers.swift
+++ b/Finicky/Finicky/Browsers.swift
@@ -12,8 +12,11 @@ enum Browser: String {
     case Opera = "com.operasoftware.Opera"
 }
 
-public func getBrowserCommand(_ bundleId: String, url: URL, openInBackground: Bool) -> [String] {
+public func getBrowserCommand(_ bundleId: String, profileName:String = "Default", url: URL, openInBackground: Bool) -> [String] {
     var command = ["open", url.absoluteString, "-b", bundleId]
+    if(bundleId == "com.google.Chrome"){
+        command = ["/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",   String(format: "--profile-directory=%@", profileName),  url.absoluteString]
+    }
 
     if openInBackground {
         command.append("-g")

--- a/Finicky/Finicky/Config.swift
+++ b/Finicky/Finicky/Config.swift
@@ -241,14 +241,17 @@ open class FinickyConfig {
                     let dict = raw as! NSMutableDictionary
                     let appType = AppDescriptorType(rawValue: dict["appType"] as! String)
                     let openInBackground: Bool? = dict["openInBackground"] as? Bool
-                    let browserName = dict["name"] as! String
-
+                    
+                    let browserAndProfile = (dict["name"] as! String).components(separatedBy:["#"]);
+                    let browserName = browserAndProfile[0];
+                    let profileName = browserAndProfile[1];
+                    
                     if browserName == "" {
                         return nil
                     }
-
+                    
                     do {
-                        let browser = try BrowserOpts(name: browserName, appType: appType!, openInBackground: openInBackground)
+                        let browser = try BrowserOpts(name: browserName, appType: appType!, openInBackground: openInBackground, profileName:profileName)
                         return browser
                     } catch _ as BrowserError {
                         showNotification(title: "Couldn't find browser \"\(browserName)\"")
@@ -270,7 +273,6 @@ open class FinickyConfig {
                         logToConsole?("Couldn't generate url from handler \(newUrl), falling back to original url")
                     }
                 }
-
                 return AppDescriptor(browsers: browsers, url: finalUrl)
             }
         }

--- a/Finicky/Finicky/Config.swift
+++ b/Finicky/Finicky/Config.swift
@@ -243,8 +243,8 @@ open class FinickyConfig {
                     let openInBackground: Bool? = dict["openInBackground"] as? Bool
                     
                     let browserAndProfile = (dict["name"] as! String).components(separatedBy:["#"]);
-                    let browserName = browserAndProfile[0];
-                    let profileName = browserAndProfile[1];
+                    let browserName = browserAndProfile[0]
+                    let profileName = browserAndProfile.count > 1 ? browserAndProfile[1] : ""
                     
                     if browserName == "" {
                         return nil

--- a/Finicky/Finicky/Utilities.swift
+++ b/Finicky/Finicky/Utilities.swift
@@ -6,7 +6,6 @@ func shell(_ args: [String]) -> Int32 {
     task.launchPath = "/usr/bin/env"
     task.arguments = args
     task.launch()
-    task.waitUntilExit()
     return task.terminationStatus
 }
 


### PR DESCRIPTION
This PR fixs #40.
Now you can add your `profile` of Google Chrome Profile
Just add you Chrome profile directory name like this:
```
// without profile
browser: 'Google Chrome'
```
```
// with profile
// On Mac OS X, the directories are located in ~/Library/Application Support/Google/Chrome
browser: 'Google Chrome#Profile 1'

// with Default profile
browser: 'Google Chrome#Default'

```
`#` is separator.


It uses `--profile-directory` option.

I just want to share something about this issue.
With the `--profile-directory` option
- `open` command with bundle id doesn't open that profile
- Run Chrome using `/Applications/Google Chrome.app/Contents/MacOS/Google Chrome` opens that profile properly.

I try to find the way to use profile directory name. But I couldn't.




