### PR TITLE
Specify browser by path

### DIFF
--- a/Finicky/Finicky/AppDelegate.swift
+++ b/Finicky/Finicky/AppDelegate.swift
@@ -201,8 +201,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
                         return browser
                     }
                 }
-            } else if browser.appPath != nil {
-                return browser
             }
         }
 

--- a/Finicky/Finicky/AppDescriptor.swift
+++ b/Finicky/Finicky/AppDescriptor.swift
@@ -34,7 +34,7 @@ public struct BrowserOpts : CustomStringConvertible {
 
         if appType == AppDescriptorType.bundleId {
             self.bundleId = name
-        } else if appType == AppDescriptorType.appPath || BrowserOpts.isAppDirectory(name) {
+        } else if appType == AppDescriptorType.appPath {
             self.appPath = name
         } else if let path = NSWorkspace.shared.fullPath(forApplication: name) {
             if let bundle = Bundle(path: path) {

--- a/Finicky/Finicky/AppDescriptor.swift
+++ b/Finicky/Finicky/AppDescriptor.swift
@@ -4,6 +4,7 @@ import Foundation
 public enum AppDescriptorType: String {
     case bundleId
     case appName
+    case appPath
     case none
 }
 
@@ -11,26 +12,46 @@ enum BrowserError: Error {
     case cantFindBrowser(msg: String)
 }
 
-public struct BrowserOpts {
+public struct BrowserOpts : CustomStringConvertible {
     public var name: String
-    public var openInBackground: Bool?
-    public var bundleId: String
+    public var openInBackground: Bool
+    public var bundleId: String?
+    public var appPath: String?
+    
+    public var description: String {
+        if let bundleId = self.bundleId {
+            return bundleId
+        } else if let appPath = self.appPath {
+            return appPath
+        } else {
+            return self.name
+        }
+    }
 
     public init(name: String, appType: AppDescriptorType, openInBackground: Bool?) throws {
         self.name = name
-        self.openInBackground = openInBackground
+        self.openInBackground = openInBackground ?? false
 
         if appType == AppDescriptorType.bundleId {
-            bundleId = name
+            self.bundleId = name
+        } else if appType == AppDescriptorType.appPath || BrowserOpts.isAppDirectory(name) {
+            self.appPath = name
         } else if let path = NSWorkspace.shared.fullPath(forApplication: name) {
             if let bundle = Bundle(path: path) {
-                bundleId = bundle.bundleIdentifier!
+                self.bundleId = bundle.bundleIdentifier!
+                self.appPath = path
             } else {
                 throw BrowserError.cantFindBrowser(msg: "Couldn't find application \"\(name)\"")
             }
         } else {
             throw BrowserError.cantFindBrowser(msg: "Couldn't find application \"\(name)\"")
         }
+    }
+    
+    public static func isAppDirectory(_ path: String) -> Bool {
+        var isDirectory = ObjCBool(true)
+        let exists = FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory)
+        return exists && isDirectory.boolValue
     }
 }
 

--- a/Finicky/Finicky/Browsers.swift
+++ b/Finicky/Finicky/Browsers.swift
@@ -20,13 +20,13 @@ public func getBrowserCommand(_ browserOpts: BrowserOpts, url: URL) -> [String] 
         command.append(contentsOf: ["-a", appPath])
     } else if let bundleId = browserOpts.bundleId {
         command.append(contentsOf: ["-b", bundleId])
+    } else {
+        
     }
 
     if browserOpts.openInBackground {
         command.append("-g")
     }
-    
-    print(command)
 
     return command
 }

--- a/Finicky/Finicky/Browsers.swift
+++ b/Finicky/Finicky/Browsers.swift
@@ -12,12 +12,21 @@ enum Browser: String {
     case Opera = "com.operasoftware.Opera"
 }
 
-public func getBrowserCommand(_ bundleId: String, url: URL, openInBackground: Bool) -> [String] {
-    var command = ["open", url.absoluteString, "-b", bundleId]
+public func getBrowserCommand(_ browserOpts: BrowserOpts, url: URL) -> [String] {
+    var command = ["open", url.absoluteString]
+    
+    // appPath takes priority over bundleId as it is always unique.
+    if let appPath = browserOpts.appPath {
+        command.append(contentsOf: ["-a", appPath])
+    } else if let bundleId = browserOpts.bundleId {
+        command.append(contentsOf: ["-b", bundleId])
+    }
 
-    if openInBackground {
+    if browserOpts.openInBackground {
         command.append("-g")
     }
+    
+    print(command)
 
     return command
 }

--- a/Finicky/Finicky/Config.swift
+++ b/Finicky/Finicky/Config.swift
@@ -308,6 +308,5 @@ open class FinickyConfig {
         FinickyAPI.setContext(ctx)
         ctx.setObject(FinickyAPI.self, forKeyedSubscript: "finickyInternalAPI" as NSCopying & NSObjectProtocol)
         ctx.evaluateScript("var finicky = finickyConfigApi.createAPI();")
-        let foo = ctx.evaluateScript("Object.keys(this)");
     }
 }

--- a/Finicky/Finicky/Config.swift
+++ b/Finicky/Finicky/Config.swift
@@ -308,5 +308,6 @@ open class FinickyConfig {
         FinickyAPI.setContext(ctx)
         ctx.setObject(FinickyAPI.self, forKeyedSubscript: "finickyInternalAPI" as NSCopying & NSObjectProtocol)
         ctx.evaluateScript("var finicky = finickyConfigApi.createAPI();")
+        let foo = ctx.evaluateScript("Object.keys(this)");
     }
 }

--- a/Finicky/Finicky/finickyConfigAPI.js
+++ b/Finicky/Finicky/finickyConfigAPI.js
@@ -244,7 +244,7 @@ var finickyConfigApi = (function (exports) {
         validate.string,
         validate.shape({
             name: validate.string.isRequired,
-            appType: validate.oneOf(["appName", "bundleId"]),
+            appType: validate.oneOf(["appName", "appPath", "bundleId"]),
             openInBackground: validate.boolean
         }),
         validate.function("options"),
@@ -286,6 +286,7 @@ var finickyConfigApi = (function (exports) {
         appType: validate.oneOf([
             validate.value("bundleId"),
             validate.value("appName"),
+            validate.value("appPath"),
             validate.value("none")
         ]).isRequired,
         openInBackground: validate.boolean
@@ -388,7 +389,13 @@ var finickyConfigApi = (function (exports) {
         if (value === null) {
             return "none";
         }
-        return looksLikeBundleIdentifier(value) ? "bundleId" : "appName";
+        if (looksLikeBundleIdentifier(value)) {
+            return "bundleId";
+        }
+        if (looksLikeAbsolutePath(value)) {
+            return "appPath";
+        }
+        return "appName";
     }
     function processBrowserResult(result, options) {
         var browser = resolveBrowser(result, options);
@@ -420,6 +427,9 @@ var finickyConfigApi = (function (exports) {
             return true;
         }
         return false;
+    }
+    function looksLikeAbsolutePath(value) {
+        return value.startsWith("/");
     }
 
     function validateConfig(config) {

--- a/config-api/src/fastidious/index.test.ts
+++ b/config-api/src/fastidious/index.test.ts
@@ -146,7 +146,7 @@ describe("test", () => {
         v.string,
         v.shape({
           name: v.string.isRequired,
-          appType: v.oneOf(["appName", "bundleId"]),
+          appType: v.oneOf(["appName", "bundleId", "appPath"]),
           openInBackground: v.boolean
         }),
         v.function("options"),
@@ -204,7 +204,7 @@ describe("Complex", () => {
         v.string,
         v.shape({
           name: v.string.isRequired,
-          appType: v.oneOf(["appName", "bundleId"]),
+          appType: v.oneOf(["appName", "bundleId", "appPath"]),
           openInBackground: v.boolean
         })
       ]).isRequired
@@ -231,7 +231,7 @@ describe("Complex", () => {
         v.string,
         v.shape({
           name: v.string.isRequired,
-          appType: v.oneOf(["appName", "bundleId"]),
+          appType: v.oneOf(["appName", "bundleId", "appPath"]),
           openInBackground: v.boolean,
           anotherShape: v.shape({
             boool: v.boolean
@@ -324,7 +324,7 @@ test.only("test x", () => {
     v.string,
     v.shape({
       name: v.string.isRequired,
-      appType: v.oneOf(["appName", "bundleId"]),
+      appType: v.oneOf(["appName", "bundleId", "appPath"]),
       openInBackground: v.boolean
     }),
     v.function("options"),

--- a/config-api/src/processUrl.ts
+++ b/config-api/src/processUrl.ts
@@ -34,6 +34,7 @@ const appDescriptorSchema = {
   appType: validate.oneOf([
     validate.value("bundleId"),
     validate.value("appName"),
+    validate.value("appPath"),
     validate.value("none")
   ]).isRequired,
   openInBackground: validate.boolean
@@ -175,7 +176,15 @@ function getAppType(value: string) {
     return "none";
   }
 
-  return looksLikeBundleIdentifier(value) ? "bundleId" : "appName";
+  if (looksLikeBundleIdentifier(value)) {
+    return "bundleId";
+  }
+
+  if (looksLikeAbsolutePath(value)) {
+    return "appPath";
+  }
+
+  return "appName";
 }
 
 function processBrowserResult(result: BrowserResult, options: Options) {
@@ -221,4 +230,8 @@ function looksLikeBundleIdentifier(value: string) {
     return true;
   }
   return false;
+}
+
+function looksLikeAbsolutePath(value: string) {
+  return value.startsWith("/");
 }

--- a/config-api/src/types.ts
+++ b/config-api/src/types.ts
@@ -173,7 +173,7 @@ const browserSchema = validate.oneOf([
   validate.string,
   validate.shape({
     name: validate.string.isRequired,
-    appType: validate.oneOf(["appName", "bundleId"]),
+    appType: validate.oneOf(["appName", "appPath", "bundleId"]),
     openInBackground: validate.boolean
   }),
   validate.function("options"),

--- a/config-api/src/types.ts
+++ b/config-api/src/types.ts
@@ -93,7 +93,7 @@ export type Browser = string | BrowserObject;
  */
 export interface BrowserObject {
   name: string;
-  appType?: "appName" | "bundleId" | "none";
+  appType?: "appName" | "bundleId" | "appPath" | "none";
   openInBackground?: boolean;
 }
 


### PR DESCRIPTION
Implements #98

I tested it with the following minimal config:

```
module.exports = {
  defaultBrowser: "com.google.Chrome",
  handlers: [
    { match: /apple/  , browser: "com.apple.Safari"         },
    { match: /mozilla/, browser: "/Applications/Firefox.app"}
  ]
};
```

As expected:
- https://apple.com opens in Safari
- https://google.com opens in Google
- https://mozilla.org opens in Firefox

I implemented the `bundleId` and `appPath` as `String?`. This makes the code a bit ugly in a few places as the compiler can't guarantee that one of the two is non-nil. Is there a better way to do this in Swift? Some kind of `Either` type, perhaps?