### PR TITLE
add support for browser profiles

### DIFF
--- a/Finicky/Finicky/AppDescriptor.swift
+++ b/Finicky/Finicky/AppDescriptor.swift
@@ -21,6 +21,7 @@ public struct BrowserOpts: CustomStringConvertible {
     public var openInBackground: Bool
     public var bundleId: String?
     public var appPath: String?
+    public var profile: String?
 
     public var description: String {
         if let bundleId = self.bundleId {
@@ -32,9 +33,10 @@ public struct BrowserOpts: CustomStringConvertible {
         }
     }
 
-    public init(name: String, appType: AppDescriptorType, openInBackground: Bool?) throws {
+    public init(name: String, appType: AppDescriptorType, openInBackground: Bool?, profile: String?) throws {
         self.name = name
         self.openInBackground = openInBackground ?? !NSApplication.shared.isActive
+        self.profile = profile
 
         if appType == AppDescriptorType.bundleId {
             bundleId = name

--- a/Finicky/Finicky/Browsers.swift
+++ b/Finicky/Finicky/Browsers.swift
@@ -2,18 +2,18 @@
 import Foundation
 
 enum Browser: String {
-    case Chrome = "com.google.Chrome"
-    case ChromeCanary = "com.google.Chrome.canary"
-    case Brave = "com.brave.Browser"
-    case BraveDev = "com.brave.Browser.dev"
-    case Safari = "com.apple.Safari"
+    case Chrome = "com.google.chrome"
+    case ChromeCanary = "com.google.chrome.canary"
+    case Brave = "com.brave.browser"
+    case BraveDev = "com.brave.browser.dev"
+    case Safari = "com.apple.safari"
     case Firefox = "org.mozilla.firefox"
     case FirefoxDeveloperEdition = "org.mozilla.firefoxdeveloperedition"
-    case Opera = "com.operasoftware.Opera"
+    case Opera = "com.operasoftware.opera"
 }
 
 public func getBrowserCommand(_ browserOpts: BrowserOpts, url: URL) -> [String] {
-    var command = ["open", url.absoluteString]
+    var command = ["open"]
 
     // appPath takes priority over bundleId as it is always unique.
     if let appPath = browserOpts.appPath {
@@ -26,5 +26,28 @@ public func getBrowserCommand(_ browserOpts: BrowserOpts, url: URL) -> [String] 
         command.append("-g")
     }
 
+    if let profile = browserOpts.profile, let bundleId: String = browserOpts.bundleId {
+        command.append("-n")
+        let profileOption: [String] = getProfileOption(bundleId: bundleId, profile: profile)
+        command.append("--args")
+        command.append(contentsOf: profileOption)
+    }
+
+    command.append(url.absoluteString)
+
     return command
+}
+
+private func getProfileOption(bundleId: String, profile: String) -> [String] {
+    var profileOption: [String] {
+        switch bundleId.lowercased() {
+        case Browser.Brave.rawValue: return ["--profile-directory=\(profile)"]
+        case Browser.BraveDev.rawValue: return ["--profile-directory=\(profile)"]
+        case Browser.Chrome.rawValue: return ["--profile-directory=\(profile)"]
+        case Browser.Firefox.rawValue: return ["-P", profile]
+        case Browser.FirefoxDeveloperEdition.rawValue: return ["-P", profile]
+        default: return [""]
+        }
+    }
+    return profileOption
 }

--- a/Finicky/Finicky/Browsers.swift
+++ b/Finicky/Finicky/Browsers.swift
@@ -27,10 +27,11 @@ public func getBrowserCommand(_ browserOpts: BrowserOpts, url: URL) -> [String] 
     }
 
     if let profile = browserOpts.profile, let bundleId: String = browserOpts.bundleId {
-        command.append("-n")
-        let profileOption: [String] = getProfileOption(bundleId: bundleId, profile: profile)
-        command.append("--args")
-        command.append(contentsOf: profileOption)
+        if let profileOption: [String] = getProfileOption(bundleId: bundleId, profile: profile) {
+            command.append("-n")
+            command.append("--args")
+            command.append(contentsOf: profileOption)
+        }
     }
 
     command.append(url.absoluteString)
@@ -38,8 +39,8 @@ public func getBrowserCommand(_ browserOpts: BrowserOpts, url: URL) -> [String] 
     return command
 }
 
-private func getProfileOption(bundleId: String, profile: String) -> [String] {
-    var profileOption: [String] {
+private func getProfileOption(bundleId: String, profile: String) -> [String]? {
+    var profileOption: [String]? {
         switch bundleId.lowercased() {
         case Browser.Brave.rawValue: return ["--profile-directory=\(profile)"]
         case Browser.BraveDev.rawValue: return ["--profile-directory=\(profile)"]
@@ -51,7 +52,7 @@ private func getProfileOption(bundleId: String, profile: String) -> [String] {
 //        case Browser.Firefox.rawValue: return ["-P", profile]
 //        case Browser.FirefoxDeveloperEdition.rawValue: return ["-P", profile]
 
-        default: return [""]
+        default: return nil
         }
     }
     return profileOption

--- a/Finicky/Finicky/Browsers.swift
+++ b/Finicky/Finicky/Browsers.swift
@@ -44,8 +44,13 @@ private func getProfileOption(bundleId: String, profile: String) -> [String] {
         case Browser.Brave.rawValue: return ["--profile-directory=\(profile)"]
         case Browser.BraveDev.rawValue: return ["--profile-directory=\(profile)"]
         case Browser.Chrome.rawValue: return ["--profile-directory=\(profile)"]
-        case Browser.Firefox.rawValue: return ["-P", profile]
-        case Browser.FirefoxDeveloperEdition.rawValue: return ["-P", profile]
+
+//        Disabling Firefox support due to unreliable performance
+//        Link: https://github.com/johnste/finicky/pull/113#issuecomment-672180597
+//
+//        case Browser.Firefox.rawValue: return ["-P", profile]
+//        case Browser.FirefoxDeveloperEdition.rawValue: return ["-P", profile]
+
         default: return [""]
         }
     }

--- a/Finicky/Finicky/Config.swift
+++ b/Finicky/Finicky/Config.swift
@@ -272,6 +272,7 @@ open class FinickyConfig {
                     let appType = AppDescriptorType(rawValue: dict["appType"] as! String)
                     let openInBackground: Bool? = dict["openInBackground"] as? Bool
                     let browserName = dict["name"] as! String
+                    let browserProfile: String? = dict["profile"] as? String
 
                     if browserName == "" {
                         return nil
@@ -279,7 +280,7 @@ open class FinickyConfig {
 
                     do {
                         // Default to opening the application in the bg if Finicky is not activated.
-                        let browser = try BrowserOpts(name: browserName, appType: appType!, openInBackground: openInBackground)
+                        let browser = try BrowserOpts(name: browserName, appType: appType!, openInBackground: openInBackground, profile:browserProfile)
                         return browser
                     } catch _ as BrowserError {
                         showNotification(title: "Couldn't find browser \"\(browserName)\"")

--- a/config-api/src/processUrl.ts
+++ b/config-api/src/processUrl.ts
@@ -41,6 +41,7 @@ const appDescriptorSchema = {
     validate.value("none"),
   ]).isRequired,
   openInBackground: validate.boolean,
+  profile: validate.string,
 };
 
 export function processUrl(

--- a/config-api/src/types.ts
+++ b/config-api/src/types.ts
@@ -96,6 +96,7 @@ export interface BrowserObject {
   name: string;
   appType?: "appName" | "bundleId" | "appPath" | "none";
   openInBackground?: boolean;
+  profile?: string;
 }
 
 /**
@@ -191,7 +192,8 @@ const browserSchema = validate.oneOf([
   validate.shape({
     name: validate.string.isRequired,
     appType: validate.oneOf(["appName", "appPath", "bundleId"]),
-    openInBackground: validate.boolean
+    openInBackground: validate.boolean,
+    profile: validate.string,
   }),
   validate.function("options"),
   validate.value(null)


### PR DESCRIPTION
Allows selecting profile of target browser.
Adds support for Google Chrome, Brave Browser and Mozzila Firefox.

Apologies in advance for not following any Swift/Javascript conventions correctly. I don't don't have much experience in either.

You can specify which browser profile target by defining the profile property on the browser object in the config file.

### Sample Config
```
module.exports = {
    defaultBrowser: {
        name: "com.brave.Browser",
        appType: "bundleId",
        profile: "Personal",
        openInBackground: false,
    },
    handlers: [
        {
            match: ({ sourceProcessPath }) =>
                sourceProcessPath && sourceProcessPath.startsWith("/Applications/Slack.app"),
            browser: {
                name: "com.brave.Browser",
                appType: "bundleId",
                profile: "Work",
                openInBackground: false,
            }
        },
    ]
};
```
