### PR TITLE
Open config menu item

### DIFF
--- a/Finicky/Finicky/AppDelegate.swift
+++ b/Finicky/Finicky/AppDelegate.swift
@@ -56,9 +56,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
             }
         }
 
-        func updateStatus(valid: Bool) {
-            openConfigMenuItem.isEnabled = valid
-            if valid {
+        func updateStatus(status: FinickyConfig.Status) {
+            openConfigMenuItem.isEnabled = status != .unavailable
+            if status == .valid {
                 statusItem.button?.image = img
             } else {
                 statusItem.button?.image = invalidImg

--- a/Finicky/Finicky/AppDelegate.swift
+++ b/Finicky/Finicky/AppDelegate.swift
@@ -57,12 +57,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
         }
 
         func updateStatus(valid: Bool) {
+            openConfigMenuItem.isEnabled = valid
             if valid {
                 statusItem.button?.image = img
-                openConfigMenuItem.isEnabled = true
             } else {
                 statusItem.button?.image = invalidImg
-                openConfigMenuItem.isEnabled = false
             }
         }
 

--- a/Finicky/Finicky/AppDelegate.swift
+++ b/Finicky/Finicky/AppDelegate.swift
@@ -8,6 +8,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
     @IBOutlet var testConfigWindow: NSWindow!
     @IBOutlet var testUrlTextField: NSTextField!
     @IBOutlet var textView: NSTextView!
+    @IBOutlet var openConfigMenuItem: NSMenuItem!
     @objc var statusItem: NSStatusItem!
 
     var configLoader: FinickyConfig!
@@ -58,8 +59,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
         func updateStatus(valid: Bool) {
             if valid {
                 statusItem.button?.image = img
+                openConfigMenuItem.isEnabled = true
             } else {
                 statusItem.button?.image = invalidImg
+                openConfigMenuItem.isEnabled = false
             }
         }
 
@@ -80,6 +83,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
 
     @IBAction func reloadConfig(_: NSMenuItem) {
         configLoader.listenToChanges(showInitialSuccess: true)
+    }
+
+    @IBAction func openConfig(_: NSMenuItem) {
+        NSWorkspace.shared.openFile((FNConfigPath as NSString).resolvingSymlinksInPath)
     }
 
     @IBAction func checkUpdates(_: NSMenuItem? = nil) {

--- a/Finicky/Finicky/Base.lproj/MainMenu.xib
+++ b/Finicky/Finicky/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17156" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16096" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17156"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16096"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -716,7 +716,7 @@
                     </connections>
                 </menuItem>
             </items>
-            <point key="canvasLocation" x="184" y="-213"/>
+            <point key="canvasLocation" x="137.5" y="-105"/>
         </menu>
         <window title="Finicky Console" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" id="VZJ-Lg-gDn">
             <windowStyleMask key="styleMask" titled="YES" closable="YES"/>
@@ -753,7 +753,7 @@
                         <autoresizingMask key="autoresizingMask"/>
                         <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="k0G-uq-6Cu">
                             <rect key="frame" x="2" y="2" width="568" height="407"/>
-                            <autoresizingMask key="autoresizingMask"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <textView editable="NO" importsGraphics="NO" richText="NO" verticallyResizable="YES" allowsCharacterPickerTouchBarItem="NO" linkDetection="YES" textCompletion="NO" id="qaM-sW-3L0">
                                     <rect key="frame" x="0.0" y="0.0" width="568" height="407"/>
@@ -780,7 +780,7 @@
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <buttonCell key="cell" type="push" title="Clear console" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="XVX-Nz-543">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                            <font key="font" metaFont="system"/>
+                            <font key="font" metaFont="message"/>
                         </buttonCell>
                         <connections>
                             <action selector="ClearConsole:" target="Voe-Tx-rLC" id="2bk-u0-Z8a"/>

--- a/Finicky/Finicky/Base.lproj/MainMenu.xib
+++ b/Finicky/Finicky/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16096" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17156" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16096"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17156"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -15,6 +15,7 @@
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModule="Finicky" customModuleProvider="target">
             <connections>
+                <outlet property="openConfigMenuItem" destination="IzB-Zp-2vO" id="Qrx-iQ-ysr"/>
                 <outlet property="statusItemMenu" destination="Kzo-ni-M3E" id="VAC-Jd-SUN"/>
                 <outlet property="testConfigWindow" destination="VZJ-Lg-gDn" id="yu6-P3-Fon"/>
                 <outlet property="testUrlTextField" destination="MSV-N8-vFV" id="R7y-rh-o03"/>
@@ -672,12 +673,18 @@
             </items>
             <point key="canvasLocation" x="263" y="-47"/>
         </menu>
-        <menu id="Kzo-ni-M3E" userLabel="Status Item Menu">
+        <menu autoenablesItems="NO" id="Kzo-ni-M3E" userLabel="Status Item Menu">
             <items>
                 <menuItem title="Reload Config" id="X9g-Uv-L2W">
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <connections>
                         <action selector="reloadConfig:" target="Voe-Tx-rLC" id="0FH-YI-ACs"/>
+                    </connections>
+                </menuItem>
+                <menuItem title="Open Config" enabled="NO" id="IzB-Zp-2vO">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <connections>
+                        <action selector="openConfig:" target="Voe-Tx-rLC" id="4UW-gs-G8h"/>
                     </connections>
                 </menuItem>
                 <menuItem title="Console..." id="B8m-5i-1Ii">
@@ -709,7 +716,7 @@
                     </connections>
                 </menuItem>
             </items>
-            <point key="canvasLocation" x="137.5" y="-105"/>
+            <point key="canvasLocation" x="184" y="-213"/>
         </menu>
         <window title="Finicky Console" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" id="VZJ-Lg-gDn">
             <windowStyleMask key="styleMask" titled="YES" closable="YES"/>
@@ -746,7 +753,7 @@
                         <autoresizingMask key="autoresizingMask"/>
                         <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="k0G-uq-6Cu">
                             <rect key="frame" x="2" y="2" width="568" height="407"/>
-                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                            <autoresizingMask key="autoresizingMask"/>
                             <subviews>
                                 <textView editable="NO" importsGraphics="NO" richText="NO" verticallyResizable="YES" allowsCharacterPickerTouchBarItem="NO" linkDetection="YES" textCompletion="NO" id="qaM-sW-3L0">
                                     <rect key="frame" x="0.0" y="0.0" width="568" height="407"/>
@@ -773,7 +780,7 @@
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                         <buttonCell key="cell" type="push" title="Clear console" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="XVX-Nz-543">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                            <font key="font" metaFont="message"/>
+                            <font key="font" metaFont="system"/>
                         </buttonCell>
                         <connections>
                             <action selector="ClearConsole:" target="Voe-Tx-rLC" id="2bk-u0-Z8a"/>


### PR DESCRIPTION
![Screenshot 2020-10-09 at 22 12 54](https://user-images.githubusercontent.com/3374306/95634030-dd4f8580-0a80-11eb-9edd-a4c0bea39092.png)

Implements #133 

Added a new menu item "Open config" right below "Reload config". When pressed, it uses `NSWorkspace.openFile` so the file should be passed to the default app associated with "js" file extension. The menu item is disabled until the config file is created.
