### PR TITLE
Fix installation instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Finicky is a macOS application that allows you to set up rules that decide which
 1. Installation alternatives:
 
 - Download [the latest release](https://github.com/johnste/finicky/releases), unzip and put `Finicky.app` in your application folder.
-- Install with [homebrew-cask](https://github.com/caskroom/homebrew-cask): `brew cask install finicky`.
+- Install with [homebrew-cask](https://github.com/caskroom/homebrew-cask): `brew install --cask finicky`.
 
 2. Create a file called `.finicky.js` with configuration
    ([examples](#example-configuration)) in your home directory OR generate a basic configuration with [Finicky Kickstart](https://finicky-kickstart.now.sh/)


### PR DESCRIPTION
Fix error when installing using latest Homebrew. This is not a bug of this app, but README.md needs to be fixed.

screenshot:

![Calling brew cask install is disabled](https://user-images.githubusercontent.com/8146876/103161978-5fa04800-482d-11eb-847b-9fcb6cb15bb2.png)
