### PR TITLE
Adds makefile and build instructions to README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,4 +3,4 @@ build:
 	cd ./Finicky && xcodebuild clean build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
 
 run:
-	open ./Finicky/build/Release/Finicky.app
+	bash ./scripts/run.sh

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+build:
+	cd config-api && yarn && yarn build
+	cd ./Finicky && xcodebuild clean build CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
+
+run:
+	open ./Finicky/build/Release/Finicky.app

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Finicky is a macOS application that allows you to set up rules that decide which
 - [Documentation](#documentation)
 - [Configuration ideas](#configuration-ideas)
 - [Alternatives](#alternatives)
+- [Building Finicky from source](#building-finicky-from-source)
 - [Support development](#support-development)
 - [Issues](#issues)
   - [Bugs](#bugs)
@@ -59,8 +60,9 @@ Finicky is a macOS application that allows you to set up rules that decide which
 
 2. Create a file called `.finicky.js` with configuration
    ([examples](#example-configuration)) in your home directory OR generate a basic configuration with [Finicky Kickstart](https://finicky-kickstart.now.sh/)
-   
+
 3. Start Finicky. Please allow it to be set as the default browser.
+
 4. And you're done. All links clicked that would have opened your browser are now first handled by Finicky.
 
 ## Example configuration
@@ -113,6 +115,18 @@ See the wiki page for other [configuration ideas](https://github.com/johnste/fin
 ## Alternatives
 
 If you are looking for something that lets you pick the browser to activate in a graphical interface, check out [Browserosaurus](https://browserosaurus.com/) by Will Stone, an open source browser prompter for macOS. It works really well together with Finicky!
+
+## Building Finicky from source
+
+If you'd like to build Finicky from source, you can do so by installing Xcode, Xcode Command Line Tools, and yarn, and then running the following:
+
+```sh
+# build the source
+make
+
+# run the compiled app
+make run
+```
 
 ## Support development
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+PROCESS=Finicky
+num_processes=$(ps aux | grep -v grep | grep -ci $PROCESS)
+
+if [ $num_processes -gt 0 ]; then
+  echo "Quitting already running Finicky"
+  osascript -e 'quit app "$PROCESS"';
+fi
+
+echo "Opening built Finicky"
+open ./Finicky/build/Release/Finicky.app

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -5,7 +5,7 @@ num_processes=$(ps aux | grep -v grep | grep -ci $PROCESS)
 
 if [ $num_processes -gt 0 ]; then
   echo "Quitting already running Finicky"
-  osascript -e 'quit app "$PROCESS"';
+  osascript -e "quit app \"$PROCESS\"";
 fi
 
 echo "Opening built Finicky"


### PR DESCRIPTION
Adds build instructions / and a makefile to make it easier to build/run the app locally. This can also deprecate the wiki page (https://github.com/johnste/finicky/wiki/Building-Finicky-from-source) now that it's documented in code (Makefile).