### PR TITLE
Add support for sending an array of arguments to a browser

### DIFF
--- a/Finicky/Finicky/AppDescriptor.swift
+++ b/Finicky/Finicky/AppDescriptor.swift
@@ -23,7 +23,6 @@ public struct BrowserOpts: CustomStringConvertible {
     public var appPath: String?
     public var profile: String?
     public var args: [String]
-    public var passUrlAsArg: Bool
 
     public var description: String {
         if let bundleId = self.bundleId {
@@ -40,14 +39,12 @@ public struct BrowserOpts: CustomStringConvertible {
         appType: AppDescriptorType,
         openInBackground: Bool?,
         profile: String?,
-        args: [String],
-        passUrlAsArg: Bool?
+        args: [String]
     ) throws {
         self.name = name
         self.openInBackground = openInBackground ?? !NSApplication.shared.isActive
         self.profile = profile
         self.args = args
-        self.passUrlAsArg = passUrlAsArg ?? true
 
         if appType == AppDescriptorType.bundleId {
             bundleId = name

--- a/Finicky/Finicky/AppDescriptor.swift
+++ b/Finicky/Finicky/AppDescriptor.swift
@@ -22,6 +22,8 @@ public struct BrowserOpts: CustomStringConvertible {
     public var bundleId: String?
     public var appPath: String?
     public var profile: String?
+    public var args: [String]
+    public var passUrlAsArg: Bool
 
     public var description: String {
         if let bundleId = self.bundleId {
@@ -33,10 +35,19 @@ public struct BrowserOpts: CustomStringConvertible {
         }
     }
 
-    public init(name: String, appType: AppDescriptorType, openInBackground: Bool?, profile: String?) throws {
+    public init(
+        name: String,
+        appType: AppDescriptorType,
+        openInBackground: Bool?,
+        profile: String?,
+        args: [String],
+        passUrlAsArg: Bool?
+    ) throws {
         self.name = name
         self.openInBackground = openInBackground ?? !NSApplication.shared.isActive
         self.profile = profile
+        self.args = args
+        self.passUrlAsArg = passUrlAsArg ?? true
 
         if appType == AppDescriptorType.bundleId {
             bundleId = name

--- a/Finicky/Finicky/Browsers.swift
+++ b/Finicky/Finicky/Browsers.swift
@@ -48,6 +48,7 @@ enum Browser: String {
 
 public func getBrowserCommand(_ browserOpts: BrowserOpts, url: URL) -> [String] {
     var command = ["open"]
+    var commandArgs: [String] = []
 
     // appPath takes priority over bundleId as it is always unique.
     if let appPath = browserOpts.appPath {
@@ -62,13 +63,25 @@ public func getBrowserCommand(_ browserOpts: BrowserOpts, url: URL) -> [String] 
 
     if let profile = browserOpts.profile, let bundleId: String = browserOpts.bundleId {
         if let profileOption: [String] = getProfileOption(bundleId: bundleId, profile: profile) {
-            command.append("-n")
-            command.append("--args")
-            command.append(contentsOf: profileOption)
+            commandArgs.append(contentsOf: profileOption)
         }
     }
 
-    command.append(url.absoluteString)
+    if browserOpts.args.count > 0 {
+        commandArgs.append(contentsOf: browserOpts.args)
+    }
+
+    if commandArgs.count > 0 {
+        command.append("-n")
+        command.append("--args")
+        command.append(contentsOf: commandArgs)
+    }
+
+    // command.append(contentsOf: ["--app-id=jhgifngagadhdmngcahhimadjfofillb", "--profile-directory=Profile 13", "--app-launch-url-for-shortcuts-menu-item=https://meet.google.com/fqu-ckzh-vap?hs=122&ijlm=1609867843360"])
+
+    if browserOpts.passUrlAsArg {
+        command.append(url.absoluteString)
+    }
 
     return command
 }

--- a/Finicky/Finicky/Browsers.swift
+++ b/Finicky/Finicky/Browsers.swift
@@ -49,6 +49,7 @@ enum Browser: String {
 public func getBrowserCommand(_ browserOpts: BrowserOpts, url: URL) -> [String] {
     var command = ["open"]
     var commandArgs: [String] = []
+    var appendUrl = true
 
     // appPath takes priority over bundleId as it is always unique.
     if let appPath = browserOpts.appPath {
@@ -69,6 +70,9 @@ public func getBrowserCommand(_ browserOpts: BrowserOpts, url: URL) -> [String] 
 
     if browserOpts.args.count > 0 {
         commandArgs.append(contentsOf: browserOpts.args)
+
+        // do not auto-append the URL when args has been explicitly defined
+        appendUrl = false
     }
 
     if commandArgs.count > 0 {
@@ -77,9 +81,7 @@ public func getBrowserCommand(_ browserOpts: BrowserOpts, url: URL) -> [String] 
         command.append(contentsOf: commandArgs)
     }
 
-    // command.append(contentsOf: ["--app-id=jhgifngagadhdmngcahhimadjfofillb", "--profile-directory=Profile 13", "--app-launch-url-for-shortcuts-menu-item=https://meet.google.com/fqu-ckzh-vap?hs=122&ijlm=1609867843360"])
-
-    if browserOpts.passUrlAsArg {
+    if appendUrl {
         command.append(url.absoluteString)
     }
 

--- a/Finicky/Finicky/Config.swift
+++ b/Finicky/Finicky/Config.swift
@@ -278,7 +278,6 @@ open class FinickyConfig {
                     let browserName = dict["name"] as! String
                     let browserProfile: String? = dict["profile"] as? String
                     let args: [String] = dict["args"] as? [String] ?? []
-                    let passUrlAsArg: Bool? = dict["passUrlAsArg"] as? Bool
 
                     if browserName == "" {
                         return nil
@@ -291,8 +290,7 @@ open class FinickyConfig {
                             appType: appType!,
                             openInBackground: openInBackground,
                             profile: browserProfile,
-                            args: args,
-                            passUrlAsArg: passUrlAsArg
+                            args: args
                         )
                         return browser
                     } catch _ as BrowserError {

--- a/Finicky/Finicky/Config.swift
+++ b/Finicky/Finicky/Config.swift
@@ -175,9 +175,9 @@ open class FinickyConfig {
         print("Reloading config")
         hasError = false
         var config: String?
-        
+
         usleep(100 * 1000) // Sleep for a few millisconds to make sure file is available (See https://github.com/johnste/finicky/issues/140)
-        
+
         do {
             let filename: String = (FNConfigPath as NSString).resolvingSymlinksInPath
             config = try String(contentsOfFile: filename, encoding: String.Encoding.utf8)
@@ -209,7 +209,7 @@ open class FinickyConfig {
             return
         }
 
-        setupAPI()        
+        setupAPI()
         ctx.evaluateScript(config)
         configObject = ctx.evaluateScript("module.exports")
 
@@ -277,6 +277,8 @@ open class FinickyConfig {
                     let openInBackground: Bool? = dict["openInBackground"] as? Bool
                     let browserName = dict["name"] as! String
                     let browserProfile: String? = dict["profile"] as? String
+                    let args: [String] = dict["args"] as? [String] ?? []
+                    let passUrlAsArg: Bool? = dict["passUrlAsArg"] as? Bool
 
                     if browserName == "" {
                         return nil
@@ -284,7 +286,14 @@ open class FinickyConfig {
 
                     do {
                         // Default to opening the application in the bg if Finicky is not activated.
-                        let browser = try BrowserOpts(name: browserName, appType: appType!, openInBackground: openInBackground, profile:browserProfile)
+                        let browser = try BrowserOpts(
+                            name: browserName,
+                            appType: appType!,
+                            openInBackground: openInBackground,
+                            profile: browserProfile,
+                            args: args,
+                            passUrlAsArg: passUrlAsArg
+                        )
                         return browser
                     } catch _ as BrowserError {
                         showNotification(title: "Couldn't find browser \"\(browserName)\"")

--- a/config-api/src/fastidious/index.test.ts
+++ b/config-api/src/fastidious/index.test.ts
@@ -147,7 +147,9 @@ describe("test", () => {
         v.shape({
           name: v.string.isRequired,
           appType: v.oneOf(["appName", "bundleId", "appPath"]),
-          openInBackground: v.boolean
+          openInBackground: v.boolean,
+          args: v.arrayOf(v.string),
+          passUrlAsArg: v.boolean,
         }),
         v.function("options"),
         v.value(null)
@@ -205,7 +207,9 @@ describe("Complex", () => {
         v.shape({
           name: v.string.isRequired,
           appType: v.oneOf(["appName", "bundleId", "appPath"]),
-          openInBackground: v.boolean
+          openInBackground: v.boolean,
+          args: v.arrayOf(v.string),
+          passUrlAsArg: v.boolean,
         })
       ]).isRequired
     };
@@ -233,6 +237,8 @@ describe("Complex", () => {
           name: v.string.isRequired,
           appType: v.oneOf(["appName", "bundleId", "appPath"]),
           openInBackground: v.boolean,
+          args: v.arrayOf(v.string),
+          passUrlAsArg: v.boolean,
           anotherShape: v.shape({
             boool: v.boolean
           })
@@ -325,7 +331,9 @@ test.only("test x", () => {
     v.shape({
       name: v.string.isRequired,
       appType: v.oneOf(["appName", "bundleId", "appPath"]),
-      openInBackground: v.boolean
+      openInBackground: v.boolean,
+      args: v.arrayOf(v.string),
+      passUrlAsArg: v.boolean,
     }),
     v.function("options"),
     v.value(null)

--- a/config-api/src/fastidious/index.test.ts
+++ b/config-api/src/fastidious/index.test.ts
@@ -149,7 +149,6 @@ describe("test", () => {
           appType: v.oneOf(["appName", "bundleId", "appPath"]),
           openInBackground: v.boolean,
           args: v.arrayOf(v.string),
-          passUrlAsArg: v.boolean,
         }),
         v.function("options"),
         v.value(null)
@@ -209,7 +208,6 @@ describe("Complex", () => {
           appType: v.oneOf(["appName", "bundleId", "appPath"]),
           openInBackground: v.boolean,
           args: v.arrayOf(v.string),
-          passUrlAsArg: v.boolean,
         })
       ]).isRequired
     };
@@ -238,7 +236,6 @@ describe("Complex", () => {
           appType: v.oneOf(["appName", "bundleId", "appPath"]),
           openInBackground: v.boolean,
           args: v.arrayOf(v.string),
-          passUrlAsArg: v.boolean,
           anotherShape: v.shape({
             boool: v.boolean
           })
@@ -333,7 +330,6 @@ test.only("test x", () => {
       appType: v.oneOf(["appName", "bundleId", "appPath"]),
       openInBackground: v.boolean,
       args: v.arrayOf(v.string),
-      passUrlAsArg: v.boolean,
     }),
     v.function("options"),
     v.value(null)

--- a/config-api/src/processUrl.ts
+++ b/config-api/src/processUrl.ts
@@ -42,6 +42,8 @@ const appDescriptorSchema = {
   ]).isRequired,
   openInBackground: validate.boolean,
   profile: validate.string,
+  args: validate.arrayOf(validate.string),
+  passUrlAsArg: validate.boolean,
 };
 
 export function processUrl(

--- a/config-api/src/processUrl.ts
+++ b/config-api/src/processUrl.ts
@@ -43,7 +43,6 @@ const appDescriptorSchema = {
   openInBackground: validate.boolean,
   profile: validate.string,
   args: validate.arrayOf(validate.string),
-  passUrlAsArg: validate.boolean,
 };
 
 export function processUrl(

--- a/config-api/src/types.ts
+++ b/config-api/src/types.ts
@@ -98,7 +98,6 @@ export interface BrowserObject {
   openInBackground?: boolean;
   profile?: string;
   args?: string[];
-  passUrlAsArg?: boolean,
 }
 
 /**
@@ -197,7 +196,6 @@ const browserSchema = validate.oneOf([
     openInBackground: validate.boolean,
     profile: validate.string,
     args: validate.arrayOf(validate.string),
-    passUrlAsArg: validate.boolean,
   }),
   validate.function("options"),
   validate.value(null)

--- a/config-api/src/types.ts
+++ b/config-api/src/types.ts
@@ -97,6 +97,8 @@ export interface BrowserObject {
   appType?: "appName" | "bundleId" | "appPath" | "none";
   openInBackground?: boolean;
   profile?: string;
+  args?: string[];
+  passUrlAsArg?: boolean,
 }
 
 /**
@@ -194,6 +196,8 @@ const browserSchema = validate.oneOf([
     appType: validate.oneOf(["appName", "appPath", "bundleId"]),
     openInBackground: validate.boolean,
     profile: validate.string,
+    args: validate.arrayOf(validate.string),
+    passUrlAsArg: validate.boolean,
   }),
   validate.function("options"),
   validate.value(null)


### PR DESCRIPTION
This PR adds support for sending arguments to the browser. This allows for some cool stuff, like directly triggering a Chrome Application Shortcut and sending the URL to it.

```js
const googleMeetApp = {
  browser: ({ urlString }) => ({
    name: "Google Chrome",
    profile: "Profile 13", // use whatever profile created the application shortcut
    args: [
      `--app-id=jhgifngagadhdmngcahhimadjfofillb`, // my app ID for my Google Meet application shortcut
      `--app-launch-url-for-shortcuts-menu-item=${urlString}`,
      // notice I'm not passing urlString as an array entry, since Chrome Application Shortcuts don't like that
    ],
  }),
}

module.exports = {
  // ...
  handlers: [
    {
      match: finicky.matchHostnames(["meet.google.com"]),
      ...googleMeetApp,
    },
  ],
};
```

The PR adds a new key to the `browser` object:

- `args` - default: `[urlString]`. an array of string args to pass to the application.

Solves #153