### PR TITLE
Add shortener for MS Teams to defaultUrlShorteners

### DIFF
--- a/Finicky/Finicky/Utilities.swift
+++ b/Finicky/Finicky/Utilities.swift
@@ -42,4 +42,5 @@ let defaultUrlShorteners = [
     "t.co",
     "tiny.cc",
     "tinyurl.com",
+    "urlshortener.teams.microsoft.com",
 ]


### PR DESCRIPTION
Add `urlshortener.teams.microsoft.com` to defaultUrlShorteners so that [this trick](https://github.com/johnste/finicky/wiki/Configuration-ideas#open-microsoft-teams-links-in-the-native-app) would also work when clicking links in emails from MS Teams.