### PR TITLE
enable profiles for Wavebox.io

### DIFF
--- a/Finicky/Finicky/Browsers.swift
+++ b/Finicky/Finicky/Browsers.swift
@@ -49,6 +49,7 @@ enum Browser: String {
     case Opera = "com.operasoftware.opera"
     case Vivaldi = "com.vivaldi.vivaldi"
     case Safari = "com.apple.safari"
+    case Wavebox = "com.bookry.wavebox"
 }
 
 public func getBrowserCommand(_ browserOpts: BrowserOpts, url: URL) -> [String] {
@@ -103,7 +104,8 @@ private func getProfileOption(bundleId: String, profile: String) -> [String]? {
             Browser.Chrome.rawValue,
             Browser.Edge.rawValue,
             Browser.EdgeBeta.rawValue,
-            Browser.Vivaldi.rawValue:
+            Browser.Vivaldi.rawValue,
+            Browser.Wavebox.rawValue:
             return ["--profile-directory=\(profile)"]
 
             // Blisk and Opera doesn't support multiple profiles even though they are Chromium based

--- a/Finicky/Finicky/Info.plist
+++ b/Finicky/Finicky/Info.plist
@@ -90,7 +90,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>310</string>
+	<string>319</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>


### PR DESCRIPTION
Wavebox.io is based on chromium underneath and has a feature called workspaces that uses browser profiles. By adding it to the list of browsers that support profiles we can use finicky to open URLs in particular workspaces.