### PR TITLE
Implement firefox container tab support

### DIFF
--- a/Finicky/Finicky/AppDescriptor.swift
+++ b/Finicky/Finicky/AppDescriptor.swift
@@ -22,6 +22,7 @@ public struct BrowserOpts: CustomStringConvertible {
     public var bundleId: String?
     public var appPath: String?
     public var profile: String?
+    public var container: String?
     public var args: [String]
 
     public var description: String {
@@ -39,6 +40,7 @@ public struct BrowserOpts: CustomStringConvertible {
         appType: AppDescriptorType,
         openInBackground: Bool?,
         profile: String?,
+        container: String?,
         args: [String]
     ) throws {
         self.name = name
@@ -54,6 +56,7 @@ public struct BrowserOpts: CustomStringConvertible {
         }
 
         self.profile = profile
+        self.container = container
         self.args = args
 
         if appType == AppDescriptorType.bundleId {

--- a/Finicky/Finicky/Config.swift
+++ b/Finicky/Finicky/Config.swift
@@ -313,6 +313,7 @@ open class FinickyConfig {
                     let openInBackground: Bool? = dict["openInBackground"] as? Bool
                     let browserName = dict["name"] as! String
                     let browserProfile: String? = dict["profile"] as? String
+                    let browserContainer: String? = dict["container"] as? String
                     let args: [String] = dict["args"] as? [String] ?? []
 
                     if browserName == "" {
@@ -326,6 +327,7 @@ open class FinickyConfig {
                             appType: appType!,
                             openInBackground: openInBackground,
                             profile: browserProfile,
+                            container: browserContainer,
                             args: args
                         )
                         return browser

--- a/config-api/src/schemas.ts
+++ b/config-api/src/schemas.ts
@@ -32,6 +32,7 @@ const browserSchema = validate.oneOf([
     appType: validate.oneOf(["appName", "appPath", "bundleId"]),
     openInBackground: validate.boolean,
     profile: validate.string,
+    container: validate.string,
     args: validate.arrayOf(validate.string),
   }),
   validate.function("options"),
@@ -100,5 +101,6 @@ export const appDescriptorSchema = {
   ]).isRequired,
   openInBackground: validate.boolean,
   profile: validate.string,
+  container: validate.string,
   args: validate.arrayOf(validate.string),
 };

--- a/config-api/src/types.ts
+++ b/config-api/src/types.ts
@@ -126,6 +126,7 @@ export interface BrowserObject {
   appType?: AppType;
   openInBackground?: boolean;
   profile?: string;
+  container?: string;
   args?: string[];
 }
 


### PR DESCRIPTION
Firefox can have container tabs enabled, and an extension exists that will allow routing external URLs with a specific format into these containers [Open External links in a container](https://addons.mozilla.org/en-GB/firefox/addon/open-url-in-container/).

This change implements logic so if configured in a `handler`, the outgoing URL is converted into this format when the browser is called.

This has an improvement over using a rewrite rule, in that the config can be kept DRY, and container selection logic is left to the handler. An example of such a rewrite rule implementation is here: https://github.com/johnste/finicky/issues/211#issuecomment-1047235912.

Example configuration:

```js
handlers: [
  {
    // Some work site
    match: "https://some-site.com/*",
    browser: {
      name: "Firefox",
      container: "Work",
    },
  },
],
```