### PR TITLE
WIP: Add JavascriptCore polyfill for require()

### DIFF
--- a/Finicky/Finicky/Config.swift
+++ b/Finicky/Finicky/Config.swift
@@ -382,5 +382,21 @@ open class FinickyConfig {
         FinickyAPI.setContext(ctx)
         ctx.setObject(FinickyAPI.self, forKeyedSubscript: "finickyInternalAPI" as NSCopying & NSObjectProtocol)
         ctx.evaluateScript("var finicky = finickyConfigApi.createAPI();")
+        
+        // Add polyfills
+        let require: @convention(block) (String) -> (JSValue?) = { path in
+            let expandedPath = NSString(string: path).expandingTildeInPath
+
+            // Return void or throw an error here.
+            guard FileManager.default.fileExists(atPath: expandedPath)
+                else { debugPrint("Require: filename \(expandedPath) does not exist")
+                       return nil }
+
+            guard let fileContent = try? String(contentsOfFile: expandedPath)
+                else { return nil }
+
+            return self.ctx.evaluateScript(fileContent)
+        }
+        ctx.setObject(require, forKeyedSubscript: "require" as NSString)
     }
 }


### PR DESCRIPTION
I want to put a number of helper functions in a separate file (see https://github.com/johnste/finicky/issues/261) including a base64 decoding function (see https://github.com/johnste/finicky/issues/223) so that I can decode and rewrite click tracking URLs where the ultimate URL is inside the base64 encoded query parameter.

(Here's my config https://github.com/jamesramsay/dotfiles/blob/main/finicky/config.js)

I wrote this as a quick proof-of-concept and have been using locally. @johnste are you open to including a polyfill like this?