### PR TITLE
Re-enable Firefox profiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,8 @@ DerivedData
 *.hmap
 *.ipa
 *.xcuserstate
-
+# As far as I can tell, these are parts of the build process
+products/
 # CocoaPods
 #
 # We recommend against adding the Pods directory to your .gitignore. However

--- a/Finicky/Finicky.xcodeproj/project.pbxproj
+++ b/Finicky/Finicky.xcodeproj/project.pbxproj
@@ -246,15 +246,14 @@
 				TargetAttributes = {
 					54899CCF1B20D5BC00647101 = {
 						CreatedOnToolsVersion = 6.3;
-						DevelopmentTeam = C3XWNKDP3M;
+						DevelopmentTeam = DM5FXX35M7;
 						LastSwiftMigration = 1020;
 						ProvisioningStyle = Automatic;
 					};
 					54899CDF1B20D5BC00647101 = {
 						CreatedOnToolsVersion = 6.3;
-						DevelopmentTeam = C3XWNKDP3M;
+						DevelopmentTeam = DM5FXX35M7;
 						LastSwiftMigration = 1020;
-						ProvisioningStyle = Automatic;
 						TestTargetID = 54899CCF1B20D5BC00647101;
 					};
 				};
@@ -405,7 +404,6 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				CODE_SIGN_IDENTITY = "Apple Development";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -464,7 +462,6 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				CODE_SIGN_IDENTITY = "Apple Development";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_HARDENED_RUNTIME = YES;
@@ -494,7 +491,7 @@
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = C3XWNKDP3M;
+				DEVELOPMENT_TEAM = DM5FXX35M7;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = Finicky/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
@@ -516,7 +513,7 @@
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = C3XWNKDP3M;
+				DEVELOPMENT_TEAM = DM5FXX35M7;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = Finicky/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
@@ -534,10 +531,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = C3XWNKDP3M;
+				DEVELOPMENT_TEAM = DM5FXX35M7;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
 					"$(inherited)",
@@ -552,6 +548,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "net.kassett.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Finicky.app/Contents/MacOS/Finicky";
 			};
@@ -561,10 +558,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "Mac Developer";
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = C3XWNKDP3M;
+				DEVELOPMENT_TEAM = DM5FXX35M7;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(DEVELOPER_FRAMEWORKS_DIR)",
 					"$(inherited)",
@@ -575,6 +571,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "net.kassett.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Finicky.app/Contents/MacOS/Finicky";
 			};

--- a/Finicky/Finicky/AppDelegate.swift
+++ b/Finicky/Finicky/AppDelegate.swift
@@ -268,7 +268,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
 
         if appDescriptor.browsers.count == 1 {
             if let browser = appDescriptor.browsers.first {
-                description += "Opens browser: \(browser.name)\(browser.openInBackground ? " (opens in background)" : "")"
+                description += "Opens browser: \(browser.name) \(browser.profile != nil ? "profile: \(browser.profile)" : "") \(browser.openInBackground ? "(opens in background)" : "")"
+//                description += "Opens browser: \(browser.name)\(browser.openInBackground ? " (opens in background)" : "")"
             }
         } else if appDescriptor.browsers.count == 0 {
             description += "Won't open any browser"

--- a/Finicky/Finicky/Browsers.swift
+++ b/Finicky/Finicky/Browsers.swift
@@ -112,11 +112,10 @@ private func getProfileOption(bundleId: String, profile: String) -> [String]? {
             // case Browser.Blisk.rawValue: return ["--profile-directory=\(profile)"]
             // case Browser.Opera.rawValue: return ["--profile-directory=\(profile)"]
 
-            // Disabling Firefox support due to unreliable performance
+            // Firefox support might have unreliable performance
             // Link: https://github.com/johnste/finicky/pull/113#issuecomment-672180597
-            //
-            // case Browser.Firefox.rawValue: return ["-P", profile]
-            // case Browser.FirefoxDeveloperEdition.rawValue: return ["-P", profile]
+             case Browser.Firefox.rawValue: return ["-P", profile]
+             case Browser.FirefoxDeveloperEdition.rawValue: return ["-P", profile]
 
         default: return nil
         }

--- a/Finicky/Finicky/Info.plist
+++ b/Finicky/Finicky/Info.plist
@@ -90,15 +90,13 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>319</string>
+	<string>326</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>LSUIElement</key>
 	<true/>
-	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2020 John Sterling</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>
 	<key>NSPrincipalClass</key>

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+This is a fork of the official finicky project, hosted on Github under /johnste/finicky.
+The ffprofiles branch re-enables the disabled Firefox profile support, and adds a comment when trying links in the app's console.
+
+--
 <div align="center">
   <h1><img
     height="100"
@@ -31,6 +35,7 @@ Finicky is a macOS application that allows you to set up rules that decide which
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
+- [Table of Contents](#table-of-contents)
 - [Installation](#installation)
 - [Example configuration](#example-configuration)
 - [Documentation](#documentation)
@@ -38,10 +43,11 @@ Finicky is a macOS application that allows you to set up rules that decide which
 - [Alternatives](#alternatives)
 - [Building Finicky from source](#building-finicky-from-source)
 - [Current status of Finicky development](#current-status-of-finicky-development)
+	- [Looking for co-maintainers](#looking-for-co-maintainers)
 - [Issues](#issues)
-  - [Bugs](#bugs)
-  - [Feature Requests](#feature-requests)
-  - [Questions](#questions)
+	- [Bugs](#bugs)
+	- [Feature Requests](#feature-requests)
+	- [Questions](#questions)
 - [License](#license)
 
 


### PR DESCRIPTION
The original app had them disabled due to performance concerns. So far, I haven't noticed these on my M1 machines.