### PR TITLE
Fix call to NSLog when logging

### DIFF
--- a/Finicky/Finicky/API.swift
+++ b/Finicky/Finicky/API.swift
@@ -20,7 +20,7 @@ import JavaScriptCore
 
     static func log(_ message: String?) {
         if message != nil {
-            NSLog(message!)
+            NSLog("%@", message!)
             logToConsole?(message!, false)
         }
     }


### PR DESCRIPTION
Calling `NSLog(message!)` will interpret message as format string (see [docs](https://developer.apple.com/documentation/foundation/1395275-nslog)), causing errors and even segfault in some edge cases. Instead, use proper format string  and message as argument.

Fixes https://github.com/johnste/finicky/issues/328.