### PR TITLE
Add support for specifying a command in browser configurations

### DIFF
--- a/Finicky/Finicky/AppDelegate.swift
+++ b/Finicky/Finicky/AppDelegate.swift
@@ -314,6 +314,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
                 url = urlComponents.url!
             }
         }
+        logToConsole("Calling url handlers for url: \(url.absoluteString)")
         shortUrlResolver.resolveUrl(url, callback: { (URL) -> Void in
             self.callUrlHandlers(opener: opener, url: URL)
         })
@@ -324,11 +325,16 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
             if let appToStart = getActiveApp(browsers: appDescriptor.browsers) {
                 var success = false
                 if let bundleId = appToStart.bundleId {
+                    logToConsole("Bundle id: \(bundleId)")
                     if NSWorkspace.shared.absolutePathForApplication(withBundleIdentifier: bundleId) != nil {
                         openUrlWithBrowser(appDescriptor.url, browserOpts: appToStart)
                         success = true
                     }
+                } else if appToStart.command != nil {
+                    openUrlWithBrowser(appDescriptor.url, browserOpts: appToStart)
+                    success = true
                 } else if let appPath = appToStart.appPath {
+                    logToConsole("App path: \(appPath)")
                     if BrowserOpts.isAppDirectory(appPath) {
                         openUrlWithBrowser(appDescriptor.url, browserOpts: appToStart)
                         success = true

--- a/Finicky/Finicky/AppDescriptor.swift
+++ b/Finicky/Finicky/AppDescriptor.swift
@@ -9,6 +9,7 @@ public enum AppDescriptorType: String {
     case bundleId
     case appName
     case appPath
+    case command
     case none
 }
 
@@ -22,6 +23,7 @@ public struct BrowserOpts: CustomStringConvertible {
     public var bundleId: String?
     public var appPath: String?
     public var profile: String?
+    public var command: String?
     public var args: [String]
 
     public var description: String {
@@ -39,6 +41,7 @@ public struct BrowserOpts: CustomStringConvertible {
         appType: AppDescriptorType,
         openInBackground: Bool?,
         profile: String?,
+        command: String?,
         args: [String]
     ) throws {
         self.name = name
@@ -54,12 +57,15 @@ public struct BrowserOpts: CustomStringConvertible {
         }
 
         self.profile = profile
+        self.command = command
         self.args = args
 
         if appType == AppDescriptorType.bundleId {
             bundleId = name
         } else if appType == AppDescriptorType.appPath {
             appPath = name
+        } else if appType == AppDescriptorType.command {
+            appPath = command
         } else if let path = NSWorkspace.shared.fullPath(forApplication: name) {
             if let bundle = Bundle(path: path) {
                 bundleId = bundle.bundleIdentifier!

--- a/Finicky/Finicky/Browsers.swift
+++ b/Finicky/Finicky/Browsers.swift
@@ -29,7 +29,6 @@ public func getActiveApp(browsers: [BrowserOpts]) -> BrowserOpts? {
 }
 
 public func openUrlWithBrowser(_ url: URL, browserOpts: BrowserOpts) {
-    print("Opening \(browserOpts) at: " + url.absoluteString)
     let command = getBrowserCommand(browserOpts, url: url)
     shell(command)
 }
@@ -54,9 +53,19 @@ enum Browser: String {
 }
 
 public func getBrowserCommand(_ browserOpts: BrowserOpts, url: URL) -> [String] {
-    var command = ["open"]
+    var command: [String] = []
     var commandArgs: [String] = []
     var appendUrl = true
+
+    // command takes priority over appPath, bundleId and openInBackground
+    if browserOpts.command != nil {
+        command.append(browserOpts.command!)
+        command.append(contentsOf: commandArgs)
+        command.append(url.absoluteString)
+        return command
+    } else {
+        command.append("open")
+    }
 
     // appPath takes priority over bundleId as it is always unique.
     if let appPath = browserOpts.appPath {

--- a/Finicky/Finicky/Config.swift
+++ b/Finicky/Finicky/Config.swift
@@ -313,6 +313,7 @@ open class FinickyConfig {
                     let openInBackground: Bool? = dict["openInBackground"] as? Bool
                     let browserName = dict["name"] as! String
                     let browserProfile: String? = dict["profile"] as? String
+                    let command: String? = dict["command"] as? String
                     let args: [String] = dict["args"] as? [String] ?? []
 
                     if browserName == "" {
@@ -326,6 +327,7 @@ open class FinickyConfig {
                             appType: appType!,
                             openInBackground: openInBackground,
                             profile: browserProfile,
+                            command: command,
                             args: args
                         )
                         return browser

--- a/Finicky/Finicky/Info.plist
+++ b/Finicky/Finicky/Info.plist
@@ -90,7 +90,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>319</string>
+	<string>336</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/config-api/src/schemas.ts
+++ b/config-api/src/schemas.ts
@@ -29,9 +29,15 @@ const browserSchema = validate.oneOf([
   validate.string,
   validate.shape({
     name: validate.string.isRequired,
-    appType: validate.oneOf(["appName", "appPath", "bundleId"]),
+    appType: validate.oneOf([
+      validate.value("bundleId"),
+      validate.value("appName"),
+      validate.value("appPath"),
+      validate.value("command"),
+    ]),
     openInBackground: validate.boolean,
     profile: validate.string,
+    command: validate.string,
     args: validate.arrayOf(validate.string),
   }),
   validate.function("options"),
@@ -96,9 +102,11 @@ export const appDescriptorSchema = {
     validate.value("bundleId"),
     validate.value("appName"),
     validate.value("appPath"),
+    validate.value("command"),
     validate.value("none"),
   ]).isRequired,
   openInBackground: validate.boolean,
   profile: validate.string,
+  command: validate.string,
   args: validate.arrayOf(validate.string),
 };


### PR DESCRIPTION
- Introduce a new `command` option in `BrowserOpts` to allow specifying a custom command to open URLs.
- Update `AppDescriptor` and relevant methods to handle the new `command` type.
- Modify the `getBrowserCommand` function to prioritize `command` over app paths and bundle IDs.
- Update configuration schema validations to include the new `command` attribute.
- Add logging for URLs, bundle IDs, and app paths for better debugging.
- Bump `CFBundleVersion` from 319 to 336 in `Info.plist`.