### PR TITLE
Log profile to console

### DIFF
--- a/Finicky/Finicky/AppDelegate.swift
+++ b/Finicky/Finicky/AppDelegate.swift
@@ -258,6 +258,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
         }
     }
 
+    func browserDescription(browser: BrowserOpts) -> String {
+        return "\(browser.name)\(browser.openInBackground ? " (opens in background)" : "")"
+    }
+
     func performTest(url: URL) {
         let opener = Application(pid: getpid())
         guard let appDescriptor = configLoader.determineOpeningApp(url: url, opener: opener) else {
@@ -268,14 +272,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
 
         if appDescriptor.browsers.count == 1 {
             if let browser = appDescriptor.browsers.first {
-                description += "Opens browser: \(browser.name)\(browser.openInBackground ? " (opens in background)" : "")"
+                description += "Opens browser: \(browserDescription(browser: browser))"
             }
         } else if appDescriptor.browsers.count == 0 {
             description += "Won't open any browser"
         } else {
             description += "Opens first active browser of: "
             for (index, browser) in appDescriptor.browsers.enumerated() {
-                description += "[\(index)]: \(browser.name) \(browser.openInBackground ? "(opens in background)" : "")"
+                description += "[\(index)]: \(browserDescription(browser: browser)))"
             }
         }
 

--- a/Finicky/Finicky/AppDelegate.swift
+++ b/Finicky/Finicky/AppDelegate.swift
@@ -259,7 +259,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSUserNotificationCenterDele
     }
 
     func browserDescription(browser: BrowserOpts) -> String {
-        return "\(browser.name)\(browser.openInBackground ? " (opens in background)" : "")"
+        var description = browser.name
+        if let profile = browser.profile {
+            description += " (in profile: \(profile))"
+        }
+        if browser.openInBackground {
+            description += " (opens in background)"
+        }
+        return description
     }
 
     func performTest(url: URL) {


### PR DESCRIPTION
I only really use one browser, and mostly use Finicky to select profiles.
This change makes it easier to debug profile selection.

Tested with config:
```js
personal = {
  name: "Google Chrome",
  profile: "Default"
}

work = {
  name: "Google Chrome",
  profile: "Profile 1"
}

module.exports = {
  defaultBrowser: personal,
  handlers: [
    {
      match:finicky.matchHostnames([/example1/]),
      browser: work
    },{
      match: finicky.matchHostnames([/example2/]),
      browser: personal
    },{
      match: finicky.matchHostnames([/example3/]),
      browser: "Google Chrome"
    }
  ]
}

```

<img width="703" alt="image" src="https://github.com/user-attachments/assets/e54aefb1-a31c-4b5f-8f10-47722882b014" />
