### PR TITLE
fix: not using URL object returned by rewriter

### DIFF
--- a/config-api/src/config.test.ts
+++ b/config-api/src/config.test.ts
@@ -81,6 +81,10 @@ describe("openUrl", () => {
           match: (url: URL) => url.href.includes("shortened"),
           url: (url: URL) => url.href + "/expanded",
         },
+        {
+          match: (url: URL) => url.href.includes("use-url-object"),
+          url: (url: URL) => new URL("https://example.com"),
+        },
       ],
     };
 
@@ -96,6 +100,10 @@ describe("openUrl", () => {
       {
         input: "https://my.shortened.url/123",
         expectedUrl: "https://my.shortened.url/123/expanded",
+      },
+      {
+        input: "https://www.use-url-object.com",
+        expectedUrl: "https://example.com/",
       },
     ];
 

--- a/config-api/src/index.ts
+++ b/config-api/src/index.ts
@@ -239,8 +239,8 @@ function rewriteUrl(
   }
 
   // Convert URL to FinickyURL if it's not already one
-  if (url instanceof URL) {
-    return new FinickyURL(url.href, options.opener || null);
+  if (rewrite instanceof URL) {
+    return new FinickyURL(rewrite.href, options.opener || null);
   }
 
   if (isLegacyURLObject(rewrite)) {


### PR DESCRIPTION
Possibly fix the rewriter not using the returned URL object.

See details here : https://github.com/johnste/finicky/issues/361#issuecomment-2710396646