### PR TITLE
feat: add typescript support for configuration files

### DIFF
--- a/config-api/src/configSchema.ts
+++ b/config-api/src/configSchema.ts
@@ -113,7 +113,8 @@ const RewriteRuleSchema = z
   })
   .describe(
     "A rewrite rule contains a matcher and a url. If the matcher matches when opening a url, the url will be rewritten to the returnedurl in the rewrite rule."
-  );
+  )
+  .identifier("UrlRewriteRule");
 
 const HandlerRuleSchema = z
   .object({
@@ -122,7 +123,8 @@ const HandlerRuleSchema = z
   })
   .describe(
     "A handler contains a matcher and a browser. If the matcher matches when opening a url, the browser in the handler will be opened."
-  );
+  )
+  .identifier("BrowserHandler");
 
 // ===== Configuration Schemas =====
 const ConfigOptionsSchema = z
@@ -165,7 +167,7 @@ export const ConfigSchema = z
    export default = {
      defaultBrowser: "Google Chrome",
      options: {
-       hideIcon: false
+       logRequests: false
      },
      handlers: [{
        match: "example.com*",

--- a/src/config/configfiles.go
+++ b/src/config/configfiles.go
@@ -61,8 +61,11 @@ func (cfw *ConfigFileWatcher) GetConfigPaths() []string {
 	} else {
 		configPaths = append(configPaths,
 			"$HOME/.finicky.js",
+			"$HOME/.finicky.ts",
 			"$HOME/.config/finicky.js",
+			"$HOME/.config/finicky.ts",
 			"$HOME/.config/finicky/finicky.js",
+			"$HOME/.config/finicky/finicky.ts",
 		)
 	}
 

--- a/src/config/vm.go
+++ b/src/config/vm.go
@@ -62,7 +62,7 @@ func (vm *VM) setup(embeddedFiles embed.FS, bundlePath string) error {
 
 	if content != nil {
 		if _, err = vm.runtime.RunString(string(content)); err != nil {
-			return fmt.Errorf("failed to run config script: %v", err)
+			return fmt.Errorf("error while running config script: %v", err)
 		}
 	} else {
 		vm.runtime.Set(vm.namespace, map[string]interface{}{})

--- a/test/example.json
+++ b/test/example.json
@@ -1,4 +1,0 @@
-{
-  "defaultBrowser": "Firefox",  
-  "*regexp*": "Safari"
-}

--- a/test/example.ts
+++ b/test/example.ts
@@ -1,0 +1,27 @@
+import type {
+  BrowserHandler,
+  FinickyConfig,
+} from "/Applications/Finicky.app/Contents/Resources/finicky.d.ts";
+
+const handler: BrowserHandler = {
+  match: (url: URL, { opener }) => {
+    return url.host.includes("workplace");
+  },
+  browser: "Firefox",
+};
+
+const config: FinickyConfig = {
+  defaultBrowser: "Google Chrome",
+  handlers: [
+    handler,
+    {
+      match: (url: URL, { opener }) => {
+        console.log("opener", opener);
+        return opener?.name.includes("Slack") || false;
+      },
+      browser: "Firefox",
+    },
+  ],
+};
+
+export default config;


### PR DESCRIPTION
- look for `~/.finicky.ts`, `~/.config/finicky.ts` or `~/.config/finicky/finicky.ts` in addition to the normal javascript files
- improve typings a bit with types for `UrlRewriteRule` and `BrowserHandler`
- add `src/example.ts` example typescript configuration