### PR TITLE
add support for esbuild symlinks

### DIFF
--- a/apps/finicky/src/config/configfiles.go
+++ b/apps/finicky/src/config/configfiles.go
@@ -130,6 +130,10 @@ func (cfw *ConfigFileWatcher) BundleConfig() (string, error) {
 		Target:      api.ES2015,
 		Format:      api.FormatIIFE,
 		GlobalName:  cfw.namespace,
+		Loader: map[string]api.Loader{
+			".ts.symlink": api.LoaderTS,
+			".js.symlink": api.LoaderJS,
+		},
 	})
 
 	if len(result.Errors) > 0 {


### PR DESCRIPTION
As I store the finicky configuration into .dotfiles repo as a .symlink this PR adds support to build files with that extension in case it is useful for someone else.