### PR TITLE
feat: add isAppRunning()

### DIFF
--- a/apps/finicky/src/config/vm.go
+++ b/apps/finicky/src/config/vm.go
@@ -95,6 +95,7 @@ func (vm *VM) setup(embeddedFiles embed.FS, bundlePath string) error {
 	vm.SetModifierKeysFunc(util.GetModifierKeys)
 	vm.SetSystemInfoFunc(util.GetSystemInfo)
 	vm.SetPowerInfoFunc(util.GetPowerInfo)
+	vm.SetIsAppRunningFunc(util.IsAppRunning)
 
 	return nil
 }
@@ -158,4 +159,10 @@ func (vm *VM) SetSystemInfoFunc(fn func() map[string]string) {
 func (vm *VM) SetPowerInfoFunc(fn func() map[string]interface{}) {
 	finicky := vm.runtime.Get("finicky").ToObject(vm.runtime)
 	finicky.Set("getPowerInfo", fn)
+}
+
+// SetIsAppRunningFunc sets the isAppRunning function in the VM
+func (vm *VM) SetIsAppRunningFunc(fn func(string) bool) {
+	finicky := vm.runtime.Get("finicky").ToObject(vm.runtime)
+	finicky.Set("isAppRunning", fn)
 }

--- a/apps/finicky/src/util/info.go
+++ b/apps/finicky/src/util/info.go
@@ -8,7 +8,10 @@ package util
 // PowerInfo struct and getPowerInfo function for power status
 */
 import "C"
-import "log/slog"
+import (
+	"log/slog"
+	"unsafe"
+)
 
 // GetModifierKeys returns the current state of modifier keys
 func GetModifierKeys() map[string]bool {
@@ -63,4 +66,14 @@ func GetPowerInfo() map[string]interface{} {
 		"isConnected": bool(info.isConnected),
 		"percentage":  percentage,
 	}
+}
+
+// IsAppRunning checks if an app with the given identifier (bundle ID or app name) is running
+func IsAppRunning(identifier string) bool {
+	cIdentifier := C.CString(identifier)
+	defer C.free(unsafe.Pointer(cIdentifier))
+
+	isRunning := C.isAppRunning(cIdentifier) != 0
+	slog.Debug("App running info", "identifier", identifier, "isRunning", isRunning)
+	return isRunning
 }

--- a/apps/finicky/src/util/info.h
+++ b/apps/finicky/src/util/info.h
@@ -26,5 +26,6 @@ typedef struct {
 ModifierKeys getModifierKeys(void);
 SystemInfo getSystemInfo(void);
 PowerInfo getPowerInfo(void);
+_Bool isAppRunning(const char* identifier);
 
 #endif /* INFO_H */

--- a/apps/finicky/src/util/info.m
+++ b/apps/finicky/src/util/info.m
@@ -90,3 +90,27 @@ PowerInfo getPowerInfo() {
 
     return info;
 }
+
+_Bool isAppRunning(const char* identifier) {
+    if (!identifier) {
+        return 0;
+    }
+
+    NSString *identifierStr = [NSString stringWithUTF8String:identifier];
+    NSArray *runningApps = [[NSWorkspace sharedWorkspace] runningApplications];
+
+    for (NSRunningApplication *app in runningApps) {
+        // Check bundle ID
+        if ([[app bundleIdentifier] isEqualToString:identifierStr]) {
+            return 1;
+        }
+
+        // Check app name
+        NSString *appName = [app localizedName];
+        if ([appName isEqualToString:identifierStr]) {
+            return 1;
+        }
+    }
+
+    return 0;
+}

--- a/packages/config-api/scripts/generate-typedefs.ts
+++ b/packages/config-api/scripts/generate-typedefs.ts
@@ -30,6 +30,7 @@ interface FinickyUtils {
         isConnected: boolean;
         percentage: number | null;
     };
+    isAppRunning: (identifier: string) => boolean;
 }
 
 declare global {


### PR DESCRIPTION
Add a new method to the finicky api: isAppRunning

It enables configurations to check if other applications are running. The function accepts bundle ids or names of applications.

Fixes #388 
