### PR TITLE
Finicky 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,18 +21,16 @@ Finicky is a macOS application that allows you to set up rules that decide which
 
 ## Table of Contents
 
-- [Getting started](#getting-started)
-- [Starter configuration](#starter-configuration)
+- [Install](#install)
+- [Basic configuration](#basic-configuration)
 - [Configuration](#documentation)
 - [Building Finicky from source](#building-finicky-from-source)
 
-## Getting started
+## Install
 
 Download from [releases](https://github.com/johnste/finicky/releases)
 
-Finicky 4+ is in beta, and should work for most cases. The documentation needs to be updated, but most Finicky v3 configurations should work. Supports MacOS 12+.
-
-## Starter configuration
+## Basic configuration
 
 Here's a short example configuration that can help you get started
 
@@ -40,9 +38,6 @@ Here's a short example configuration that can help you get started
 // ~/.finicky.js
 export default {
   defaultBrowser: "Google Chrome",
-  {
-    checkForUpdate: true
-  },
   rewrite: [
     {
       // Redirect all x.com urls to use xcancel.com
@@ -54,11 +49,6 @@ export default {
     },
   ],
   handlers: [
-    {
-      // Open apple.com and example.com urls in Safari
-      match: ["apple.com*", "example.com*"],
-      browser: "Safari",
-    },
     {
       // Open any url that includes the string "workplace" in Firefox
       match: "bsky.app/*",

--- a/README.md
+++ b/README.md
@@ -87,12 +87,7 @@ Finicky has extensive support for matching, rewriting and starting browsers or o
 
 ## Building Finicky from source
 
-If you'd like to build Finicky from source:
-
-1. Install Go 1.23.4
-2. Install Node 22
-3. Run `./scripts/install.sh` from base folder to install dependencies
-4. Run `./scripts/build.sh` from base folder to build Finicky
+See [Building Finicky from source](https://github.com/johnste/finicky/wiki/Building-Finicky-from-source)
 
 ### Works well with
 

--- a/README.md
+++ b/README.md
@@ -6,28 +6,25 @@
  <strong>Always open the right browser</strong><br>
     <br/>
 
-
 </div>
 
-Finicky is a macOS application that allows you to set up rules that decide which browser is opened for every link or url. With Finicky as your default browser, you can tell it to open Facebook or Reddit in one browser, and Trello or LinkedIn in another.
+Finicky is a macOS application that allows you to set up rules that decide which browser is opened for every url. With Finicky as your default browser, you can tell it to open Bluesky or Reddit in one browser, and LinkedIn or Google Meet in another.
 
-- Decide what urls to open in what browser or app
-- Edit urls before opening them
-- Complete control over configuration using JavaScript
-
-
+- Route any URL to your preferred browser with powerful matching rules
+- Automatically edit URLs before opening them (e.g., force HTTPS, remove tracking parameters)
+- Write rules in JavaScript or TypeScript for complete control
+- Create complex routing logic with regular expressions and custom functions
+- Handle multiple browsers and apps with a single configuration
+- Keep your workflow organized by separating work and personal browsing
 
 [![GitHub prerelease](https://badgen.net/github/release/johnste/finicky?color=purple)](https://GitHub.com/johnste/finicky/releases/) ![MIT License](https://badgen.net/github/license/johnste/finicky) ![Finicky v4 release](https://badgen.net/github/milestones/johnste/finicky/6?color=pink)
 
 ## Table of Contents
 
 - [Getting started](#getting-started)
-- [Example configuration](#example-configuration)
-- [Documentation](#documentation)
-- [Configuration tips](#configuration-tips)
-- [Alternatives](#alternatives)
+- [Starter configuration](#starter-configuration)
+- [Configuration](#documentation)
 - [Building Finicky from source](#building-finicky-from-source)
-- [License](#license)
 
 ## Getting started
 
@@ -35,22 +32,23 @@ Download from [releases](https://github.com/johnste/finicky/releases)
 
 Finicky 4+ is in beta, and should work for most cases. The documentation needs to be updated, but most Finicky v3 configurations should work. Supports MacOS 12+.
 
-Finicky 3.4.0 is the latest stable release, but it is a few years old and unsupported.
+## Starter configuration
 
-
-
-## Example configuration
+Here's a short example configuration that can help you get started
 
 ```js
 // ~/.finicky.js
-export default { 
+export default {
   defaultBrowser: "Google Chrome",
+  {
+    checkForUpdate: true
+  },
   rewrite: [
     {
-      // Redirect all urls to use https
-      match: (url) => url.protocol === "http:",
+      // Redirect all x.com urls to use xcancel.com
+      match: "x.com/*",
       url: (url) => {
-        url.protocol = "https:";
+        url.host = "xcancel.com";
         return url;
       },
     },
@@ -63,14 +61,14 @@ export default {
     },
     {
       // Open any url that includes the string "workplace" in Firefox
-      match: /workplace/,
+      match: "bsky.app/*",
       browser: "Firefox",
     },
     {
       // Open google.com and *.google.com urls in Google Chrome
       match: [
-        "google.com*", // match google.com urls
-        "*.google.com*", // match google.com subdomains
+        "google.com/*", // match google.com urls
+        "*.google.com*", // also match google.com subdomains
       ],
       browser: "Google Chrome",
     },
@@ -78,23 +76,14 @@ export default {
 };
 ```
 
-See the [documentation](#documentation) for all the features Finicky supports.
+See the [configuration](#configuration) for all the features Finicky supports.
 
-## Documentation
+## Configuration
 
-Finicky has extensive support for matching, rewriting and starting browsers or other application that handle urls. See the wiki for the [full configuration documentation](https://github.com/johnste/finicky/wiki/Configuration-(v3)) explaining all available, APIs and options as well as detail information on how to match on urls.
+Finicky has extensive support for matching, rewriting and starting browsers or other application that handle urls. See the wiki for the [full configuration documentation](<https://github.com/johnste/finicky/wiki/Configuration-(v4)>) explaining available, APIs and options as well as detail information on how to match on urls.
 
-⚠️ Please note that Finicky 4 will affect the interface slightly, details to come ⚠️
-
-## Configuration tips
-
-See the wiki page for other [configuration tips](https://github.com/johnste/finicky/wiki/Configuration-ideas) by users of Finicky.
-
-⚠️ Please note that Finicky 4 will affect the interface slightly, details to come ⚠️
-
-## Alternatives
-
-If you are looking for something that lets you pick the browser to activate in a graphical interface, check out [Browserosaurus](https://browserosaurus.com/) by Will Stone, an open source browser prompter for macOS. It works really well together with Finicky!
+- The wiki has some good [configuration ideas](https://github.com/johnste/finicky/wiki/Configuration-ideas).
+- Visit [discussions](https://github.com/johnste/finicky/discussions) to discuss supporting specific apps.
 
 ## Building Finicky from source
 
@@ -104,6 +93,10 @@ If you'd like to build Finicky from source:
 2. Install Node 22
 3. Run `./scripts/install.sh` from base folder to install dependencies
 4. Run `./scripts/build.sh` from base folder to build Finicky
+
+### Works well with
+
+If you are looking for something that lets you pick the browser to activate in a graphical interface, check out [Browserosaurus](https://browserosaurus.com/) by Will Stone, an open source browser prompter for macOS. It works really well together with Finicky!
 
 ### Questions
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ Finicky is a macOS application that allows you to set up rules that decide which
 
 ## Install
 
-Download from [releases](https://github.com/johnste/finicky/releases)
+- Download from [releases](https://github.com/johnste/finicky/releases)
+- Or install via homebrew: `brew install --cask finicky`
 
 ## Basic configuration
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ Finicky is a macOS application that allows you to set up rules that decide which
 - [Install](#install)
 - [Basic configuration](#basic-configuration)
 - [Configuration](#documentation)
-- [Building Finicky from source](#building-finicky-from-source)
 
 ## Install
 
@@ -75,7 +74,9 @@ Finicky has extensive support for matching, rewriting and starting browsers or o
 - The wiki has some good [configuration ideas](https://github.com/johnste/finicky/wiki/Configuration-ideas).
 - Visit [discussions](https://github.com/johnste/finicky/discussions) to discuss supporting specific apps.
 
-## Building Finicky from source
+# Other
+
+### Building Finicky from source
 
 See [Building Finicky from source](https://github.com/johnste/finicky/wiki/Building-Finicky-from-source)
 

--- a/apps/finicky/assets/Info.plist
+++ b/apps/finicky/assets/Info.plist
@@ -17,9 +17,9 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>4.0.0-beta.3</string>
+    <string>4.0.0</string>
     <key>CFBundleVersion</key>
-    <string>4.0.0-beta.3</string>
+    <string>4.0.0</string>
     <key>CFBundleIconFile</key>
     <string>finicky.icns</string>
     <key>LSUIElement</key>

--- a/apps/finicky/assets/Info.plist
+++ b/apps/finicky/assets/Info.plist
@@ -17,9 +17,9 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>4.0.0-beta.2</string>
+    <string>4.0.0-beta.3</string>
     <key>CFBundleVersion</key>
-    <string>4.0.0-beta.2</string>
+    <string>4.0.0-beta.3</string>
     <key>CFBundleIconFile</key>
     <string>finicky.icns</string>
     <key>LSUIElement</key>

--- a/apps/finicky/src/version/version.go
+++ b/apps/finicky/src/version/version.go
@@ -205,7 +205,7 @@ func CheckForUpdatesIfEnabled(vm *goja.Runtime) (releaseInfo *ReleaseInfo, updat
 	}
 
 	// Check checkForUpdates option
-	shouldCheckForUpdates, err := vm.RunString("finickyConfigAPI.getOption('checkForUpdates', finalConfig)")
+	shouldCheckForUpdates, err := vm.RunString("finickyConfigAPI.getOption('checkForUpdates', finalConfig, true)")
 	if err != nil {
 		return nil, true, fmt.Errorf("failed to get checkForUpdates option: %v", err)
 	}

--- a/example-config/example.ts
+++ b/example-config/example.ts
@@ -10,7 +10,7 @@ const handler: BrowserHandler = {
   browser: "Firefox",
 };
 
-const config: FinickyConfig = {
+export default {
   defaultBrowser: "Google Chrome",
   handlers: [
     handler,
@@ -22,6 +22,4 @@ const config: FinickyConfig = {
       browser: "Firefox",
     },
   ],
-};
-
-export default config;
+} satisfies FinickyConfig;

--- a/packages/config-api/src/index.ts
+++ b/packages/config-api/src/index.ts
@@ -58,13 +58,13 @@ export function getConfiguration(namespace: string): Config {
   );
 }
 
-export function getOption<T>(
+export function getOption<T, K extends keyof Config["options"]>(
   option: keyof Config["options"],
   config: Config,
   defaultValue: T
-): unknown {
+): T | K {
   return config.options && option in config.options
-    ? config.options[option]
+    ? (config.options[option] as K)
     : defaultValue;
 }
 

--- a/packages/config-api/src/index.ts
+++ b/packages/config-api/src/index.ts
@@ -58,13 +58,14 @@ export function getConfiguration(namespace: string): Config {
   );
 }
 
-export function getOption(
+export function getOption<T>(
   option: keyof Config["options"],
-  config: Config
+  config: Config,
+  defaultValue: T
 ): unknown {
   return config.options && option in config.options
     ? config.options[option]
-    : undefined;
+    : defaultValue;
 }
 
 export function getConfigState(config: Config) {


### PR DESCRIPTION
Release preparation

Fixes #393

- [x] Update README with Finicky 4 imagery and configuration
- [ ] Update wiki pages, tagging existing v3 pages as unsupported
- [x] Add new wiki pages for v4 (configuration, tips, etc)
- [x] Update examples
- Update version
- Enable update checking by default
