### PR TITLE
fix: avoid sending duplicate log entries

### DIFF
--- a/apps/finicky/src/logger/logger.go
+++ b/apps/finicky/src/logger/logger.go
@@ -112,7 +112,3 @@ func Close() {
 	}
 }
 
-// GetBufferedLogs returns all logs stored in memory
-func GetBufferedLogs() string {
-	return memLog.String()
-}

--- a/apps/finicky/src/main.go
+++ b/apps/finicky/src/main.go
@@ -298,15 +298,6 @@ func ShowTheMainWindow(err error) {
 	currentVersion := version.GetCurrentVersion()
 	window.SendMessageToWebView("version", currentVersion)
 
-
-	// Send all buffered logs
-	bufferedLogs := logger.GetBufferedLogs()
-	for _, line := range strings.Split(bufferedLogs, "\n") {
-		if line != "" {
-			window.SendMessageToWebView("log", line)
-		}
-	}
-
 	<-windowClosed
 	slog.Info("Window closed, exiting")
 	tearDown()

--- a/packages/finicky-ui/src/components/LogContent.svelte
+++ b/packages/finicky-ui/src/components/LogContent.svelte
@@ -9,7 +9,7 @@
 </script>
 
 <ol class="log-content" bind:this={logContent}>
-  {#each messageBuffer as entry (entry.time)}
+  {#each messageBuffer as entry}
     {#if showDebug || entry.level.toLowerCase() !== "debug"}
       <li class="log-entry">
         <span class="log-time" title={entry.time}>


### PR DESCRIPTION
A previous method of buffering logs was still around, leading to duplicate logs being sent. This in turn caused an issue when using the time field as a unique key field when iterating over the log items.

We fix this by:
a. removing the duplicate log instances being sent
b. not using `time` as a unique key (there's no guarantee that they will be unique). 

Fixes #398 