### PR TITLE
feat: detect if app is being run in the foreground or not

### DIFF
--- a/apps/finicky/assets/Info.plist
+++ b/apps/finicky/assets/Info.plist
@@ -23,7 +23,7 @@
     <key>CFBundleIconFile</key>
     <string>finicky.icns</string>
     <key>LSUIElement</key>
-    <string>1</string>
+    <string>0</string>
     <key>CFBundleURLTypes</key>
     <array>
       <dict>

--- a/apps/finicky/src/browser/launcher.go
+++ b/apps/finicky/src/browser/launcher.go
@@ -25,7 +25,7 @@ type BrowserResult struct {
 type BrowserConfig struct {
 	Name             string   `json:"name"`
 	AppType          string   `json:"appType"`
-	OpenInBackground bool     `json:"openInBackground"`
+	OpenInBackground *bool    `json:"openInBackground"`
 	Profile          string   `json:"profile"`
 	Args             []string `json:"args"`
 	URL              string   `json:"url"`
@@ -38,7 +38,7 @@ type browserInfo struct {
 	Type              string `json:"type"`
 }
 
-func LaunchBrowser(config BrowserConfig, dryRun bool) error {
+func LaunchBrowser(config BrowserConfig, dryRun bool, openInBackgroundByDefault bool) error {
 	if config.AppType == "none" {
 		slog.Info("AppType is 'none', not launching any browser")
 		return nil
@@ -54,7 +54,14 @@ func LaunchBrowser(config BrowserConfig, dryRun bool) error {
 		openArgs = []string{"-a", config.Name}
 	}
 
-	if config.OpenInBackground {
+
+	var openInBackground bool = openInBackgroundByDefault
+
+	if config.OpenInBackground != nil {
+		openInBackground = *config.OpenInBackground
+	}
+
+	if openInBackground {
 		openArgs = append(openArgs, "-g")
 	}
 

--- a/apps/finicky/src/main.h
+++ b/apps/finicky/src/main.h
@@ -10,11 +10,12 @@
 #include <stdbool.h>
 
 extern void HandleURL(char *url, char *name, char *bundleId, char *path);
-extern void QueueWindowDisplay(int launchedByUser);
+extern void QueueWindowDisplay(int launchedByUser, int openInBackground);
 
 #ifdef __OBJC__
 @interface BrowseAppDelegate: NSObject<NSApplicationDelegate>
     @property (nonatomic) BOOL forceOpenWindow;
+    @property (nonatomic) BOOL receivedURL;
     - (instancetype)initWithForceOpenWindow:(BOOL)forceOpenWindow;
     - (void)handleGetURLEvent:(NSAppleEventDescriptor *) event withReplyEvent:(NSAppleEventDescriptor *)replyEvent;
     - (BOOL)application:(NSApplication *)sender openFile:(NSString *)filename;

--- a/packages/config-api/src/configSchema.ts
+++ b/packages/config-api/src/configSchema.ts
@@ -90,7 +90,7 @@ const BrowserConfigSchema = z
 export const BrowserConfigStrictSchema = z.object({
   name: z.string(),
   appType: z.enum(appTypes),
-  openInBackground: z.boolean(),
+  openInBackground: z.boolean().optional(),
   profile: z.string(),
   args: z.array(z.string()),
   url: z.string(),

--- a/packages/config-api/src/index.ts
+++ b/packages/config-api/src/index.ts
@@ -130,7 +130,7 @@ export function createBrowserConfig(
 ): Omit<BrowserConfigStrict, "url"> {
   const defaults = {
     appType: "appName" as const,
-    openInBackground: false,
+    openInBackground: undefined,
     profile: "",
     args: [],
   };


### PR DESCRIPTION
To be able to detect if the resulting browser is supposed to be run in the background, Finicky itself needs to be able to detect if it is activated or not. This PR updates the app to not run in the background by default, which enables this behavior.

Based on the activation status, Finicky knows which fallback value it should provide to `openInBackground`