### PR TITLE
feat: use os.UserCacheDir to get the cache path

### DIFF
--- a/apps/finicky/src/config/cache.go
+++ b/apps/finicky/src/config/cache.go
@@ -274,7 +274,7 @@ func getFinickyCacheDir() string {
 		cacheDir = os.TempDir()
 	}
 
-	finickyCacheDir := filepath.Join(cacheDir, "finicky")
+	finickyCacheDir := filepath.Join(cacheDir, "Finicky")
 	err = os.MkdirAll(finickyCacheDir, 0755)
 	if err != nil {
 		slog.Debug("Could not create finicky cache directory", "error", err)

--- a/apps/finicky/src/version/version.go
+++ b/apps/finicky/src/version/version.go
@@ -42,12 +42,12 @@ func GetBuildInfo() (string, string) {
 }
 
 func getCacheDir() string {
-	homeDir, err := os.UserHomeDir()
+	cacheDir, err := os.UserCacheDir()
 	if err != nil {
-		slog.Error("Error getting user home directory", "error", err)
+		slog.Error("Error getting user cache directory", "error", err)
 		return ""
 	}
-	cacheDir := filepath.Join(homeDir, "Library", "Caches", "Finicky")
+	cacheDir = filepath.Join(cacheDir, "Finicky")
 	if err := os.MkdirAll(cacheDir, 0755); err != nil {
 		slog.Error("Error creating cache directory", "error", err)
 		return ""


### PR DESCRIPTION
Improve the cache directory resolution by using `os.UserCacheDir` instead of building it relative to the home dir