### PR TITLE
Load system functions before running config

### DIFF
--- a/apps/finicky/src/config/vm.go
+++ b/apps/finicky/src/config/vm.go
@@ -65,6 +65,12 @@ func (vm *VM) setup(embeddedFiles embed.FS, bundlePath string) error {
 		finicky[key] = userAPI.Get(key)
 	}
 
+	// Set system-specific functions
+	finicky["getModifierKeys"] = util.GetModifierKeys
+	finicky["getSystemInfo"] = util.GetSystemInfo
+	finicky["getPowerInfo"] = util.GetPowerInfo
+	finicky["isAppRunning"] = util.IsAppRunning
+
 	vm.runtime.Set("finicky", finicky)
 
 	if content != nil {
@@ -90,12 +96,6 @@ func (vm *VM) setup(embeddedFiles embed.FS, bundlePath string) error {
 	if !validConfig.ToBoolean() {
 		return fmt.Errorf("configuration is invalid")
 	}
-
-	// Set system-specific functions
-	vm.SetModifierKeysFunc(util.GetModifierKeys)
-	vm.SetSystemInfoFunc(util.GetSystemInfo)
-	vm.SetPowerInfoFunc(util.GetPowerInfo)
-	vm.SetIsAppRunningFunc(util.IsAppRunning)
 
 	return nil
 }
@@ -141,28 +141,4 @@ func (vm *VM) GetConfigState() *ConfigState {
 // Runtime returns the underlying goja.Runtime
 func (vm *VM) Runtime() *goja.Runtime {
 	return vm.runtime
-}
-
-// SetModifierKeysFunc sets the getModifierKeys function in the VM
-func (vm *VM) SetModifierKeysFunc(fn func() map[string]bool) {
-	finicky := vm.runtime.Get("finicky").ToObject(vm.runtime)
-	finicky.Set("getModifierKeys", fn)
-}
-
-// SetSystemInfoFunc sets the getSystemInfo function in the VM
-func (vm *VM) SetSystemInfoFunc(fn func() map[string]string) {
-	finicky := vm.runtime.Get("finicky").ToObject(vm.runtime)
-	finicky.Set("getSystemInfo", fn)
-}
-
-// SetPowerInfoFunc sets the getPowerInfo function in the VM
-func (vm *VM) SetPowerInfoFunc(fn func() map[string]interface{}) {
-	finicky := vm.runtime.Get("finicky").ToObject(vm.runtime)
-	finicky.Set("getPowerInfo", fn)
-}
-
-// SetIsAppRunningFunc sets the isAppRunning function in the VM
-func (vm *VM) SetIsAppRunningFunc(fn func(string) bool) {
-	finicky := vm.runtime.Get("finicky").ToObject(vm.runtime)
-	finicky.Set("isAppRunning", fn)
 }


### PR DESCRIPTION
This fixes an issue where functions like finicky.getSystemInfo weren't available until after the config had already been loaded. In practical terms, these methods weren't available until a matcher was being called.

This change fixes the bug by removing the setter methods and setting the functions immediately when the finicky object is created in the VM, rather than after all JS has been loaded.

Fixes #429