### PR TITLE
Add aka.ms to the shortener domains. Closes #453

### DIFF
--- a/apps/finicky/src/shorturl/shortener_domains.json
+++ b/apps/finicky/src/shorturl/shortener_domains.json
@@ -1,4 +1,5 @@
 [
+  "aka.ms",
   "bit.ly",
   "buff.ly",
   "d.to",
@@ -13,6 +14,5 @@
   "tiny.cc",
   "tinyurl.com",
   "urlshortener.teams.microsoft.com",
-  "wu8.in",
-  "aka.ms"
+  "wu8.in"
 ]

--- a/apps/finicky/src/shorturl/shortener_domains.json
+++ b/apps/finicky/src/shorturl/shortener_domains.json
@@ -13,5 +13,6 @@
   "tiny.cc",
   "tinyurl.com",
   "urlshortener.teams.microsoft.com",
-  "wu8.in"
+  "wu8.in",
+  "aka.ms"
 ]


### PR DESCRIPTION
This small PR adds `aka.ms` to the list of domain shorteners so short URLs used by Microsoft (examples of which can be found here https://github.com/microsoft/aka) are processed correctly by Finicky v4.