### PR TITLE
Use macOS directory APIs

### DIFF
--- a/apps/finicky/src/browser/launcher.go
+++ b/apps/finicky/src/browser/launcher.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"al.essio.dev/pkg/shellescape"
+	"finicky/util"
 )
 
 //go:embed browsers.json
@@ -156,7 +157,7 @@ func resolveBrowserProfileArgument(identifier string, profile string) (string, b
 	if profile != "" {
 		switch matchedBrowser.Type {
 		case "Chromium":
-			homeDir, err := os.UserHomeDir()
+			homeDir, err := util.UserHomeDir()
 			if err != nil {
 				slog.Info("Error getting home directory", "error", err)
 				return "", false

--- a/apps/finicky/src/config/cache.go
+++ b/apps/finicky/src/config/cache.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"finicky/util"
 	"finicky/version"
 )
 
@@ -60,7 +61,7 @@ func (cc *ConfigCache) GetCachedBundle(configPath string) (string, bool) {
 		if err == nil && !fileInfo.ModTime().After(cc.cachedModTime) {
 			// Verify bundled file still exists
 			if _, err := os.Stat(cc.cachedBundlePath); err == nil {
-				slog.Debug("Using cached bundled config", "path", strings.Replace(cc.cachedBundlePath, os.Getenv("HOME"), "~", 1), "version", cc.appVersion)
+				slog.Debug("Using cached bundled config", "path", cc.cachedBundlePath, "version", cc.appVersion)
 				return cc.cachedBundlePath, true
 			} else {
 				slog.Debug("Cached bundle file no longer exists, rebundling")
@@ -137,8 +138,8 @@ func (cc *ConfigCache) loadCache() {
 		cc.cachedBundlePath = cacheData.BundlePath
 		cc.cachedModTime = cacheData.ModTime
 		slog.Debug("Loaded config cache",
-			"configPath", strings.Replace(cacheData.ConfigPath, os.Getenv("HOME"), "~", 1),
-			"bundlePath", strings.Replace(cacheData.BundlePath, os.Getenv("HOME"), "~", 1),
+			"configPath", cacheData.ConfigPath,
+			"bundlePath", cacheData.BundlePath,
 			"version", cacheData.AppVersion)
 	}
 }
@@ -268,7 +269,7 @@ func CleanupOldFiles(subDir string, currentFile string) {
 // creating it if it doesn't exist.
 func getFinickyCacheDir() string {
 	// Get cache directory in user's cache directory
-	cacheDir, err := os.UserCacheDir()
+	cacheDir, err := util.UserCacheDir()
 	if err != nil {
 		slog.Debug("Could not get user cache directory", "error", err)
 		cacheDir = os.TempDir()

--- a/apps/finicky/src/logger/logger.go
+++ b/apps/finicky/src/logger/logger.go
@@ -2,13 +2,13 @@ package logger
 
 import (
 	"bytes"
+	"finicky/util"
 	"finicky/window"
 	"fmt"
 	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 )
 
@@ -69,9 +69,9 @@ func SetupFile(shouldLog bool) error {
 		return nil
 	}
 
-	homeDir, err := os.UserHomeDir()
+	homeDir, err := util.UserHomeDir()
 	if err != nil {
-		return fmt.Errorf("failed to get user home directory: %v", err)
+		return fmt.Errorf("failed to get user home directory: %w", err)
 	}
 
 	logDir := filepath.Join(homeDir, "Library", "Logs", "Finicky")
@@ -88,7 +88,7 @@ func SetupFile(shouldLog bool) error {
 		return fmt.Errorf("failed to open log file: %v", err)
 	}
 
-	slog.Info("Log file created", "path", strings.Replace(logFile, os.Getenv("HOME"), "~", 1))
+	slog.Info("Log file created", "path", logFile)
 
 	// Write buffered logs to file
 	if _, err := file.Write(memLog.Bytes()); err != nil {

--- a/apps/finicky/src/main.go
+++ b/apps/finicky/src/main.go
@@ -207,7 +207,7 @@ func main() {
 func handleRuntimeError(err error) {
 	slog.Error("Failed evaluating url", "error", err)
 	lastError = err
-	go QueueWindowDisplay(1, 0)
+	go QueueWindowDisplay(1, 0, C.CString(""))
 }
 
 //export HandleURL
@@ -303,7 +303,10 @@ func handleFatalError(errorMessage string) {
 }
 
 //export QueueWindowDisplay
-func QueueWindowDisplay(openWindow int32, isActive int32) {
+func QueueWindowDisplay(openWindow int32, isActive int32, homeDir *C.char) {
+
+	slog.Debug("Home directory detected via obj-c", "homeDir", C.GoString(homeDir))
+
 	openInBackgroundByDefault = isActive != 0
 	queueWindowOpen <- openWindow != 0
 }

--- a/apps/finicky/src/main.go
+++ b/apps/finicky/src/main.go
@@ -207,7 +207,7 @@ func main() {
 func handleRuntimeError(err error) {
 	slog.Error("Failed evaluating url", "error", err)
 	lastError = err
-	go QueueWindowDisplay(1, 0, C.CString(""))
+	go QueueWindowDisplay(1, 0)
 }
 
 //export HandleURL
@@ -303,9 +303,7 @@ func handleFatalError(errorMessage string) {
 }
 
 //export QueueWindowDisplay
-func QueueWindowDisplay(openWindow int32, isActive int32, homeDir *C.char) {
-
-	slog.Debug("Home directory detected via obj-c", "homeDir", C.GoString(homeDir))
+func QueueWindowDisplay(openWindow int32, isActive int32) {
 
 	openInBackgroundByDefault = isActive != 0
 	queueWindowOpen <- openWindow != 0
@@ -407,7 +405,7 @@ func setupVM(cfw *config.ConfigFileWatcher, embeddedFS embed.FS, namespace strin
 				Handlers:       currentConfigState.Handlers,
 				Rewrites:       currentConfigState.Rewrites,
 				DefaultBrowser: currentConfigState.DefaultBrowser,
-				ConfigPath:     strings.Replace(configPath, os.Getenv("HOME"), "~", 1),
+				ConfigPath:     configPath,
 			}
 
 			window.SendMessageToWebView("config", map[string]interface{}{

--- a/apps/finicky/src/main.h
+++ b/apps/finicky/src/main.h
@@ -10,7 +10,7 @@
 #include <stdbool.h>
 
 extern void HandleURL(char *url, char *name, char *bundleId, char *path);
-extern void QueueWindowDisplay(int launchedByUser, int openInBackground);
+extern void QueueWindowDisplay(int launchedByUser, int openInBackground, char *homeDir);
 
 #ifdef __OBJC__
 @interface BrowseAppDelegate: NSObject<NSApplicationDelegate>

--- a/apps/finicky/src/main.h
+++ b/apps/finicky/src/main.h
@@ -10,7 +10,7 @@
 #include <stdbool.h>
 
 extern void HandleURL(char *url, char *name, char *bundleId, char *path);
-extern void QueueWindowDisplay(int launchedByUser, int openInBackground, char *homeDir);
+extern void QueueWindowDisplay(int launchedByUser, int openInBackground);
 
 #ifdef __OBJC__
 @interface BrowseAppDelegate: NSObject<NSApplicationDelegate>

--- a/apps/finicky/src/main.m
+++ b/apps/finicky/src/main.m
@@ -26,9 +26,7 @@
         openWindow = !self.receivedURL;
     }
 
-    NSString *homeDir = NSHomeDirectory();
-
-    QueueWindowDisplay(openWindow, openInBackground, (char*)[homeDir UTF8String]);
+    QueueWindowDisplay(openWindow, openInBackground);
 }
 
 - (void)applicationWillFinishLaunching:(NSNotification *)aNotification

--- a/apps/finicky/src/main.m
+++ b/apps/finicky/src/main.m
@@ -26,8 +26,9 @@
         openWindow = !self.receivedURL;
     }
 
-    NSLog(@"Madeleine openWindow: %d openInBackground: %d", openWindow, openInBackground);
-    QueueWindowDisplay(openWindow, openInBackground);
+    NSString *homeDir = NSHomeDirectory();
+
+    QueueWindowDisplay(openWindow, openInBackground, (char*)[homeDir UTF8String]);
 }
 
 - (void)applicationWillFinishLaunching:(NSNotification *)aNotification

--- a/apps/finicky/src/util/directories.go
+++ b/apps/finicky/src/util/directories.go
@@ -1,0 +1,25 @@
+package util
+
+/*
+#include "info.h"
+*/
+import "C"
+import "fmt"
+
+// UserHomeDir returns the user's home directory using NSHomeDirectory
+func UserHomeDir() (string, error) {
+	dir := C.GoString(C.getNSHomeDirectory())
+	if dir == "" {
+		return "", fmt.Errorf("failed to get user home directory")
+	}
+	return dir, nil
+}
+
+// UserCacheDir returns the user's cache directory using NSSearchPathForDirectoriesInDomains
+func UserCacheDir() (string, error) {
+	dir := C.GoString(C.getNSCacheDirectory())
+	if dir == "" {
+		return "", fmt.Errorf("failed to get user cache directory")
+	}
+	return dir, nil
+}

--- a/apps/finicky/src/util/info.h
+++ b/apps/finicky/src/util/info.h
@@ -27,5 +27,7 @@ ModifierKeys getModifierKeys(void);
 SystemInfo getSystemInfo(void);
 PowerInfo getPowerInfo(void);
 _Bool isAppRunning(const char* identifier);
+const char* getNSHomeDirectory(void);
+const char* getNSCacheDirectory(void);
 
 #endif /* INFO_H */

--- a/apps/finicky/src/util/info.m
+++ b/apps/finicky/src/util/info.m
@@ -2,6 +2,8 @@
 #import <Cocoa/Cocoa.h>
 #import <IOKit/ps/IOPSKeys.h>
 #import <IOKit/ps/IOPowerSources.h>
+#import <stdlib.h>
+#import <string.h>
 
 ModifierKeys getModifierKeys() {
     NSEventModifierFlags flags = [NSEvent modifierFlags];
@@ -113,4 +115,18 @@ _Bool isAppRunning(const char* identifier) {
     }
 
     return 0;
+}
+
+const char* getNSHomeDirectory(void) {
+    NSString *homeDirString = NSHomeDirectory();
+    return [homeDirString UTF8String];
+}
+
+const char* getNSCacheDirectory(void) {
+    NSArray *paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
+    if (paths.count > 0) {
+        NSString *cacheDirString = [paths objectAtIndex:0];
+        return [cacheDirString UTF8String];
+    }
+    return NULL;
 }

--- a/apps/finicky/src/version/version.go
+++ b/apps/finicky/src/version/version.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"time"
 
+	"finicky/util"
+
 	"github.com/Masterminds/semver"
 	"github.com/dop251/goja"
 )
@@ -43,7 +45,7 @@ func GetBuildInfo() (string, string) {
 }
 
 func getCacheDir() string {
-	cacheDir, err := os.UserCacheDir()
+	cacheDir, err := util.UserCacheDir()
 	if err != nil {
 		slog.Error("Error getting user cache directory", "error", err)
 		return ""


### PR DESCRIPTION
- Adds a new finicky/util package for common directory-related stuff
- Replaces direct os.UserHomeDir and os.UserCacheDir calls with custom versions that use macOS-specific APIs
- Fixes #412 