### PR TITLE
Add Microsoft Safe Links to shortener_domains.json

### DIFF
--- a/apps/finicky/src/shorturl/shortener_domains.json
+++ b/apps/finicky/src/shorturl/shortener_domains.json
@@ -8,6 +8,7 @@
   "is.gd",
   "msteams.link",
   "ow.ly",
+  "safelinks.protection.outlook.com",
   "shorturl.at",
   "spoti.fi",
   "t.co",


### PR DESCRIPTION
Hiya, submitting a PR to add an entry to `shortener_domains.json`, for some that I used in v3 per the discussion in #453.

Microsoft Safe Links has an optional URL rewriting feature that rewrites URLs in emails, Teams messages, etc. to track user clicks: https://learn.microsoft.com/en-us/defender-office-365/safe-links-about#safe-links-settings-for-email-messages

The following domains are known to be used:

- nam01.safelinks.protection.outlook.com
- nam02.safelinks.protection.outlook.com
- nam03.safelinks.protection.outlook.com
- nam04.safelinks.protection.outlook.com

Based off it using a suffix match, it looks like just adding safelinks.protection.outlook.com should be sufficient to cover them all, but happy to update the PR if you'd rather I include all four variants.