### PR TITLE
Check whether --args is already present in args

### DIFF
--- a/apps/finicky/src/browser/launcher.go
+++ b/apps/finicky/src/browser/launcher.go
@@ -10,7 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-        "slices"
+	"slices"
 
 	"al.essio.dev/pkg/shellescape"
 	"finicky/util"
@@ -77,9 +77,9 @@ func LaunchBrowser(config BrowserConfig, dryRun bool, openInBackgroundByDefault 
 
 	// Add --args if we have profile args or custom args
 	if ok || hasCustomArgs {
-                if ! slices.Contains(config.Args, "--args") {
-		        openArgs = append(openArgs, "--args")
-                }
+		if ! slices.Contains(config.Args, "--args") {
+			openArgs = append(openArgs, "--args")
+		}
 		// Add profile argument first if present
 		if ok {
 			openArgs = append(openArgs, profileArgument)

--- a/apps/finicky/src/browser/launcher.go
+++ b/apps/finicky/src/browser/launcher.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+        "slices"
 
 	"al.essio.dev/pkg/shellescape"
 	"finicky/util"
@@ -76,8 +77,9 @@ func LaunchBrowser(config BrowserConfig, dryRun bool, openInBackgroundByDefault 
 
 	// Add --args if we have profile args or custom args
 	if ok || hasCustomArgs {
-		openArgs = append(openArgs, "--args")
-
+                if ! slices.Contains(config.Args, "--args") {
+		        openArgs = append(openArgs, "--args")
+                }
 		// Add profile argument first if present
 		if ok {
 			openArgs = append(openArgs, profileArgument)


### PR DESCRIPTION
Aims to address #431 

I've tested locally both with an `args` containing `--args` and one without and got the desired behavior for each.