### PR TITLE
Allow firefox profiles?

### DIFF
--- a/apps/finicky/src/browser/browsers.json
+++ b/apps/finicky/src/browser/browsers.json
@@ -76,5 +76,15 @@
     "id": "com.operasoftware.OperaGX",
     "type": "Chromium",
     "app_name": "Opera GX"
+  },
+  {
+    "id": "org.mozilla.firefoxdeveloperedition",
+    "type": "Firefox",
+    "app_name": "Firefox Developer Edition"
+  },
+  {
+    "id": "org.mozilla.firefox",
+    "type": "Firefox",
+    "app_name": "Firefox"
   }
 ]

--- a/apps/finicky/src/browser/launcher.go
+++ b/apps/finicky/src/browser/launcher.go
@@ -12,8 +12,9 @@ import (
 	"strings"
 	"slices"
 
-	"al.essio.dev/pkg/shellescape"
 	"finicky/util"
+
+	"al.essio.dev/pkg/shellescape"
 )
 
 //go:embed browsers.json
@@ -171,6 +172,8 @@ func resolveBrowserProfileArgument(identifier string, profile string) (string, b
 
 	if profile != "" {
 		switch matchedBrowser.Type {
+		case "Firefox":
+			return "-P=" + shellescape.Quote(profile), true
 		case "Chromium":
 			homeDir, err := util.UserHomeDir()
 			if err != nil {


### PR DESCRIPTION
Hi, sorry about the unprompted PR feel free to close/reject but a little context: 

I mostly use Finicky to open URLs on a specific Firefox profile based on the opener app's name. Even though v3 didn't officially support Firefox (iirc), I got it working with args as a workaround:

<details>
<summary>V3 Config:</summary>

```js
// Use https://finicky-kickstart.now.sh to generate basic configuration
// Learn more about configuration options: https://github.com/johnste/finicky/wiki/Configuration
module.exports = {
  defaultBrowser: ({ urlString }) => ({
    name: "Firefox Developer Edition",
    args: ["-P", "00-Work", `${urlString}`],
  }),
  handlers: [
    {
      match: ({ opener }) => /telegram|spark|spotify/i.test(opener.name),
      browser: ({ urlString }) => ({
        name: "Firefox Developer Edition",
        args: ["-P", "90-Personal", `${urlString}`],
      }),
    },
  ],
};
```

</details>

This broke completely in V4 and I hit probably the same issue as #431, #460 made it less broken but I was still missing the `--new`/`-n` flag on `open`, so it would just switch to the correct window with this config:

<details>
<summary>V4 Config (not working)</summary>

```typescript
import type {
  BrowserSpecification,
  FinickyConfig,
} from "/Applications/Finicky.app/Contents/Resources/finicky.d.ts";

const workFirefox: BrowserSpecification = url => ({
  name: "Firefox Developer Edition",
  args: ['-P="90-Personal"', url.toString()]
});

const nonWorkFirefox: BrowserSpecification = url => ({
  name: "Firefox Developer Edition",
  args: ['-P="90-Personal"', url.toString()]
});

const config = {
  defaultBrowser: workFirefox,
  handlers: [
    {
      match: (_, { opener }) =>
        /telegram|spark|spotify/i.test(opener?.name ?? ""),
      browser: nonWorkFirefox,
    },
  ],
} satisfies FinickyConfig;

export default config;

```

</details>


So I decided to look into the code a little bit, and ended up making this change. I got the following config to work now, correctly opening the right profile and I no longer have to use the args workaround at all.

<details>
<summary>V4 Config (working)</summary>

```typescript
import type {
  BrowserSpecification,
  FinickyConfig,
} from "/Applications/Finicky.app/Contents/Resources/finicky.d.ts";

const workFirefox: BrowserSpecification = {
  name: "Firefox Developer Edition",
  profile: "00-Work",
};

const nonWorkFirefox: BrowserSpecification = {
  ...workFirefox,
  profile: "90-Personal",
};

const config = {
  defaultBrowser: workFirefox,
  handlers: [
    {
      match: (_, { opener }) =>
        /telegram|spark|spotify/i.test(opener?.name ?? ""),
      browser: nonWorkFirefox,
    },
  ],
} satisfies FinickyConfig;

export default config;

```

</details>

I don't know if there are some side-effects to doing this, unless this breaks something I don't really see a reason why firefox profiles shouldn't be allowed the same way Chrome/ium profiles are. (I guess this closes #90).
