### PR TITLE
feat: add support for Perplexity Comet browser

### DIFF
--- a/apps/finicky/src/browser/browsers.json
+++ b/apps/finicky/src/browser/browsers.json
@@ -52,5 +52,11 @@
     "id": "net.imput.helium",
     "type": "Chromium",
     "app_name": "Helium"
+  },
+  {
+    "config_dir_relative": "Comet",
+    "id": "ai.perplexity.comet",
+    "type": "Chromium",
+    "app_name": "Comet"
   }
 ]


### PR DESCRIPTION
This PR adds support for Perplexity Comet. Comet is Chromium based, so the usual features like profiles etc. are all supported.

[Perplexity Comet Homepage](https://www.perplexity.ai/comet)