### PR TITLE
docs: fix configuration anchor link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Finicky is a macOS application that allows you to set up rules that decide which
 
 - [Installation](#installation)
 - [Basic configuration](#basic-configuration)
-- [Configuration](#documentation)
+- [Configuration](#configuration)
 - [Migrating from Finicky 3](#migrating-from-finicky-3)
 
 ## Installation


### PR DESCRIPTION
Update the Configuration link in `README.md` to point to `#configuration` instead of the incorrect `#documentation` anchor