### PR TITLE
Terminate duplicate Finicky instances at launch (fixes #515)

### DIFF
--- a/apps/finicky/src/main.m
+++ b/apps/finicky/src/main.m
@@ -28,6 +28,8 @@
 
 // Use bool for openWindow and related logic
 - (void)applicationDidFinishLaunching:(NSNotification *)notification {
+    [self terminateOtherInstances];
+
     bool openWindow = self.forceOpenWindow;
     if (!openWindow) {
         // Even if we aren't forcing the window to open, we still want to open it if didn't receive a URL
@@ -42,6 +44,33 @@
     }
 
     QueueWindowDisplay(openWindow);
+}
+
+// Ensure only one Finicky process is running. macOS's Launch Services normally
+// routes GetURL events to an already-running instance, but that routing can fail
+// (stale LS registration after app moves/updates, different bundle paths, SSO
+// agents launching from another context) and silently spawn a second process
+// that proceeds to create its own status bar icon. Without a guard, duplicates
+// accumulate in the menu bar over time. Terminate any other instances we find
+// with the same bundle identifier so we're the single surviving process.
+- (void)terminateOtherInstances {
+    NSString *selfBundleID = [[NSBundle mainBundle] bundleIdentifier];
+    if (!selfBundleID) {
+        return;
+    }
+
+    NSArray<NSRunningApplication *> *instances = [NSRunningApplication runningApplicationsWithBundleIdentifier:selfBundleID];
+    pid_t myPID = [[NSRunningApplication currentApplication] processIdentifier];
+
+    for (NSRunningApplication *app in instances) {
+        if ([app processIdentifier] == myPID) continue;
+        if ([app isTerminated]) continue;
+
+        NSLog(@"Terminating duplicate Finicky instance (pid %d)", [app processIdentifier]);
+        if (![app terminate]) {
+            [app forceTerminate];
+        }
+    }
 }
 
 - (BOOL)applicationShouldHandleReopen:(NSApplication *)sender hasVisibleWindows:(BOOL)flag {

--- a/apps/finicky/src/main.m
+++ b/apps/finicky/src/main.m
@@ -62,14 +62,42 @@
     NSArray<NSRunningApplication *> *instances = [NSRunningApplication runningApplicationsWithBundleIdentifier:selfBundleID];
     pid_t myPID = [[NSRunningApplication currentApplication] processIdentifier];
 
+    NSMutableArray<NSRunningApplication *> *duplicates = [NSMutableArray array];
     for (NSRunningApplication *app in instances) {
         if ([app processIdentifier] == myPID) continue;
         if ([app isTerminated]) continue;
+        [duplicates addObject:app];
+    }
 
+    if (duplicates.count == 0) {
+        return;
+    }
+
+    // -[NSRunningApplication terminate] returning YES only means the request was
+    // sent, not that the target has exited. Fire all requests in parallel, then
+    // share a single deadline across the poll so 16 hung duplicates don't cost
+    // 16x the wait budget.
+    for (NSRunningApplication *app in duplicates) {
         NSLog(@"Terminating duplicate Finicky instance (pid %d)", [app processIdentifier]);
-        if (![app terminate]) {
-            [app forceTerminate];
+        [app terminate];
+    }
+
+    NSDate *deadline = [NSDate dateWithTimeIntervalSinceNow:1.0];
+    while ([deadline timeIntervalSinceNow] > 0) {
+        BOOL anyAlive = NO;
+        for (NSRunningApplication *app in duplicates) {
+            if (![app isTerminated]) { anyAlive = YES; break; }
         }
+        if (!anyAlive) return;
+
+        [[NSRunLoop currentRunLoop] runMode:NSDefaultRunLoopMode
+                                 beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.05]];
+    }
+
+    for (NSRunningApplication *app in duplicates) {
+        if ([app isTerminated]) continue;
+        NSLog(@"Duplicate Finicky instance (pid %d) did not exit within 1s; force-terminating", [app processIdentifier]);
+        [app forceTerminate];
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes the menu-bar-pile-up described in #515: Finicky has no single-instance guard, so whenever macOS spawns a second process (stale Launch Services registration after app moves/updates, different bundle paths, SSO/enterprise-auth agents launching from another context) a new status bar item accumulates and never gets reaped.

Adds a simple guard at the top of `applicationDidFinishLaunching:` in `apps/finicky/src/main.m`: enumerate `[NSRunningApplication runningApplicationsWithBundleIdentifier:]` and call `[app terminate]` (falling back to `forceTerminate`) on any instance that isn't us. Normal operation is unaffected — there's nothing to terminate when no duplicates exist.

## Why this approach

- No `LSMultipleInstancesProhibited` in `Info.plist` and no runtime check previously existed; the app relied entirely on Launch Services routing GetURL events to the existing instance, which fails in the scenarios above.
- Terminating other instances (rather than self-terminating) means the *newest* launch wins. This is what you want when the existing instance is stale (old bundle path, zombie from a prior user session, etc.), which is exactly the failure mode users report.
- Simple and bounded — no IPC, no lock files, no restructuring of the launch flow.

## Test plan

Verified locally:

- [x] Built the patched app as `Finicky-test.app` (via `BUILD_TARGET_ARCH=test ./scripts/build.sh`).
- [x] Before launch, `pgrep -fl Finicky` showed **16 running instances** on my machine (the exact scenario from #515).
- [x] After `open apps/finicky/build/Finicky-test.app`, only 1 process remains — the new one.
- [x] `log show --predicate 'processImagePath CONTAINS "Finicky-test"'` shows 16 `Terminating duplicate Finicky instance (pid N)` lines, one per stale instance.
- [x] Menu bar returned to a single Finicky icon.

## Notes

- Normal startup cost is a single `NSRunningApplication` enumeration — negligible.
- Edge case: two Finicky processes launched near-simultaneously would each try to terminate the other. This is extremely rare in practice (URL events don't typically fire that close together), and the worst-case outcome is that both die and the next URL event relaunches a single fresh instance — no worse than the current behavior.
- Bundle identifier is read from `[[NSBundle mainBundle] bundleIdentifier]` at runtime, so it stays correct if the bundle ID is ever renamed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The app now ensures only one instance runs at a time on startup. Duplicate running instances are detected, logged, and asked to exit gracefully; the app waits briefly for them to close and will force terminate any remaining duplicates before proceeding. This prevents multiple copies from running concurrently and avoids startup conflicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->