### PR TITLE
fix: strdup ObjC strings returned across CGo boundary

### DIFF
--- a/apps/finicky/src/util/directories.go
+++ b/apps/finicky/src/util/directories.go
@@ -1,17 +1,21 @@
 package util
 
 /*
+#include <stdlib.h>
 #include "info.h"
 */
 import "C"
 import (
 	"fmt"
 	"strings"
+	"unsafe"
 )
 
 // UserHomeDir returns the user's home directory using NSHomeDirectory
 func UserHomeDir() (string, error) {
-	dir := C.GoString(C.getNSHomeDirectory())
+	cDir := C.getNSHomeDirectory()
+	defer C.free(unsafe.Pointer(cDir))
+	dir := C.GoString(cDir)
 	if dir == "" {
 		return "", fmt.Errorf("failed to get user home directory")
 	}
@@ -32,7 +36,12 @@ func ShortenPath(path string) string {
 
 // UserCacheDir returns the user's cache directory using NSSearchPathForDirectoriesInDomains
 func UserCacheDir() (string, error) {
-	dir := C.GoString(C.getNSCacheDirectory())
+	cDir := C.getNSCacheDirectory()
+	if cDir == nil {
+		return "", fmt.Errorf("failed to get user cache directory")
+	}
+	defer C.free(unsafe.Pointer(cDir))
+	dir := C.GoString(cDir)
 	if dir == "" {
 		return "", fmt.Errorf("failed to get user cache directory")
 	}

--- a/apps/finicky/src/util/info.go
+++ b/apps/finicky/src/util/info.go
@@ -39,6 +39,8 @@ func GetModifierKeys() map[string]bool {
 // GetSystemInfo returns system information
 func GetSystemInfo() map[string]string {
 	info := C.getSystemInfo()
+	defer C.free(unsafe.Pointer(info.localizedName))
+	defer C.free(unsafe.Pointer(info.name))
 	return map[string]string{
 		"localizedName": C.GoString(info.localizedName),
 		"name":          C.GoString(info.name),

--- a/apps/finicky/src/util/info.h
+++ b/apps/finicky/src/util/info.h
@@ -24,10 +24,10 @@ typedef struct {
 } PowerInfo;
 
 ModifierKeys getModifierKeys(void);
-SystemInfo getSystemInfo(void);
+SystemInfo getSystemInfo(void); /* caller must free localizedName and name */
 PowerInfo getPowerInfo(void);
 _Bool isAppRunning(const char* identifier);
-const char* getNSHomeDirectory(void);
-const char* getNSCacheDirectory(void);
+const char* getNSHomeDirectory(void);  /* caller must free */
+const char* getNSCacheDirectory(void); /* caller must free; may return NULL */
 
 #endif /* INFO_H */

--- a/apps/finicky/src/util/info.m
+++ b/apps/finicky/src/util/info.m
@@ -24,8 +24,8 @@ SystemInfo getSystemInfo() {
     NSString *nameStr = [currentHost name] ?: @"";
 
     SystemInfo info = {
-        .localizedName = [localizedNameStr UTF8String],
-        .name = [nameStr UTF8String]
+        .localizedName = strdup([localizedNameStr UTF8String]),
+        .name = strdup([nameStr UTF8String])
     };
     return info;
 }
@@ -119,14 +119,14 @@ _Bool isAppRunning(const char* identifier) {
 
 const char* getNSHomeDirectory(void) {
     NSString *homeDirString = NSHomeDirectory();
-    return [homeDirString UTF8String];
+    return strdup([homeDirString UTF8String]);
 }
 
 const char* getNSCacheDirectory(void) {
     NSArray *paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, true);
     if (paths.count > 0) {
         NSString *cacheDirString = [paths objectAtIndex:0];
-        return [cacheDirString UTF8String];
+        return strdup([cacheDirString UTF8String]);
     }
     return NULL;
 }

--- a/apps/finicky/src/util/info_test.go
+++ b/apps/finicky/src/util/info_test.go
@@ -1,0 +1,61 @@
+//go:build darwin
+
+package util
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGetSystemInfo(t *testing.T) {
+	info := GetSystemInfo()
+
+	if info["localizedName"] == "" {
+		t.Error("localizedName is empty")
+	}
+	if info["name"] == "" {
+		t.Error("name is empty")
+	}
+}
+
+func TestUserHomeDir(t *testing.T) {
+	dir, err := UserHomeDir()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.HasPrefix(dir, "/") {
+		t.Errorf("expected absolute path, got %q", dir)
+	}
+}
+
+func TestUserCacheDir(t *testing.T) {
+	dir, err := UserCacheDir()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.HasPrefix(dir, "/") {
+		t.Errorf("expected absolute path, got %q", dir)
+	}
+}
+
+func TestShortenPath(t *testing.T) {
+	home, err := UserHomeDir()
+	if err != nil {
+		t.Skip("could not get home dir")
+	}
+
+	cases := []struct {
+		input string
+		want  string
+	}{
+		{home, "~"},
+		{home + "/foo/bar", "~/foo/bar"},
+		{"/other/path", "/other/path"},
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := ShortenPath(c.input); got != c.want {
+			t.Errorf("ShortenPath(%q) = %q, want %q", c.input, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
UTF8String pointers into NSString buffers become dangling once the autorelease pool drains. Use strdup so callers own the memory, and pair each call site in Go with C.free via defer.

Affected: getSystemInfo, getNSHomeDirectory, getNSCacheDirectory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory management and resource cleanup to prevent potential leaks in system utility functions.
  * Enhanced error handling with additional nil-checks for cache directory operations.

* **Tests**
  * Added comprehensive test coverage for system information and directory utility functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->