### PR TITLE
Route `ASWebAuthenticationSession` URLs

### DIFF
--- a/apps/finicky/assets/Info.plist
+++ b/apps/finicky/assets/Info.plist
@@ -22,6 +22,11 @@
     <string>4.4.0-alpha</string>
     <key>CFBundleIconFile</key>
     <string>finicky.icns</string>
+    <key>ASWebAuthenticationSessionWebBrowserSupportCapabilities</key>
+    <dict>
+      <key>IsSupported</key>
+      <true/>
+    </dict>
     <key>LSUIElement</key>
     <true/>
     <key>CFBundleURLTypes</key>

--- a/apps/finicky/assets/Info.plist
+++ b/apps/finicky/assets/Info.plist
@@ -26,6 +26,8 @@
     <dict>
       <key>IsSupported</key>
       <true/>
+      <key>CallbackURLMatchingIsSupported</key>
+      <true/>
     </dict>
     <key>LSUIElement</key>
     <true/>

--- a/apps/finicky/assets/Info.plist
+++ b/apps/finicky/assets/Info.plist
@@ -40,6 +40,15 @@
         <array>
           <string>http</string>
           <string>https</string>
+        </array>
+      </dict>
+      <dict>
+        <key>CFBundleTypeRole</key>
+        <string>Viewer</string>
+        <key>CFBundleURLName</key>
+        <string>Finicky URL</string>
+        <key>CFBundleURLSchemes</key>
+        <array>
           <string>finicky</string>
         </array>
       </dict>

--- a/apps/finicky/src/main.go
+++ b/apps/finicky/src/main.go
@@ -2,7 +2,7 @@ package main
 
 /*
 #cgo CFLAGS: -x objective-c
-#cgo LDFLAGS: -framework Cocoa -framework CoreServices
+#cgo LDFLAGS: -framework Cocoa -framework CoreServices -framework AuthenticationServices
 #include <stdlib.h>
 #include "main.h"
 */

--- a/apps/finicky/src/main.go
+++ b/apps/finicky/src/main.go
@@ -68,6 +68,7 @@ func main() {
 	startTime := time.Now()
 	logger.Setup()
 	runtime.LockOSThread()
+	C.InstallAuthenticationSessionHandler()
 
 	// Define command line flags
 	configPathPtr := flag.String("config", "", "Path to custom JS configuration file")

--- a/apps/finicky/src/main.h
+++ b/apps/finicky/src/main.h
@@ -27,5 +27,6 @@ extern char* GetCurrentConfigPath();
 #endif
 
 void RunApp(bool forceOpenWindow, bool showStatusItem, bool keepRunning);
+void InstallAuthenticationSessionHandler(void);
 
 #endif /* MAIN_H */

--- a/apps/finicky/src/main.m
+++ b/apps/finicky/src/main.m
@@ -55,6 +55,9 @@
         return NO;
     }
 
+    // Callback matching is best-effort: Finicky can complete callbacks that
+    // re-enter Finicky, but it cannot observe navigations after forwarding the
+    // auth URL to the concrete browser selected by the user's rules.
     for (NSUUID *uuid in [self.requests allKeys]) {
         ASWebAuthenticationSessionRequest *request = self.requests[uuid];
 #pragma clang diagnostic push

--- a/apps/finicky/src/main.m
+++ b/apps/finicky/src/main.m
@@ -33,7 +33,17 @@
     }
 
     self.requests[request.UUID] = request;
-    HandleURL((char *)[[request.URL absoluteString] UTF8String], NULL, NULL, NULL, NULL, false);
+
+    // AuthenticationServices does not expose the requesting app here, and
+    // Finicky cannot transfer the ASWebAuthenticationSessionRequest to the
+    // browser it chooses. Treat this as a normal URL routing request with a
+    // stable synthetic opener so rules can target SSO/OAuth flows explicitly.
+    HandleURL((char *)[[request.URL absoluteString] UTF8String],
+              "AuthenticationServices",
+              "com.apple.AuthenticationServices",
+              "",
+              NULL,
+              false);
 }
 
 - (void)cancelWebAuthenticationSessionRequest:(ASWebAuthenticationSessionRequest *)request {
@@ -47,7 +57,10 @@
 
     for (NSUUID *uuid in [self.requests allKeys]) {
         ASWebAuthenticationSessionRequest *request = self.requests[uuid];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         NSString *callbackURLScheme = request.callbackURLScheme;
+#pragma clang diagnostic pop
         if (callbackURLScheme.length == 0) {
             continue;
         }
@@ -67,10 +80,19 @@
 
 @end
 
+static FinickyAuthenticationSessionHandler *sharedAuthenticationSessionHandler;
+
+void InstallAuthenticationSessionHandler(void) {
+    if (!sharedAuthenticationSessionHandler) {
+        sharedAuthenticationSessionHandler = [[FinickyAuthenticationSessionHandler alloc] init];
+    }
+
+    [ASWebAuthenticationSessionWebBrowserSessionManager sharedManager].sessionHandler = sharedAuthenticationSessionHandler;
+}
+
 // Extend BrowseAppDelegate to hold a status item and declare menu action
 @interface BrowseAppDelegate ()
 @property (nonatomic, strong) NSStatusItem *statusItem;
-@property (nonatomic, strong) FinickyAuthenticationSessionHandler *authenticationSessionHandler;
 - (void)showWindowAction:(id)sender;
 @end
 
@@ -225,8 +247,7 @@
                     andSelector:@selector(handleGetURLEvent:withReplyEvent:)
                     forEventClass:kInternetEventClass andEventID:kAEGetURL];
 
-    self.authenticationSessionHandler = [[FinickyAuthenticationSessionHandler alloc] init];
-    [ASWebAuthenticationSessionWebBrowserSessionManager sharedManager].sessionHandler = self.authenticationSessionHandler;
+    InstallAuthenticationSessionHandler();
 }
 
 - (bool)application:(NSApplication *)sender openFile:(NSString *)filename {
@@ -259,7 +280,7 @@
     self.receivedURL = true;
 
     NSURL *eventURL = [NSURL URLWithString:urlString];
-    if ([self.authenticationSessionHandler completeRequestWithCallbackURL:eventURL]) {
+    if ([sharedAuthenticationSessionHandler completeRequestWithCallbackURL:eventURL]) {
         return;
     }
 
@@ -320,7 +341,7 @@
         return false;
     }
 
-    if ([self.authenticationSessionHandler completeRequestWithCallbackURL:url]) {
+    if ([sharedAuthenticationSessionHandler completeRequestWithCallbackURL:url]) {
         return true;
     }
 

--- a/apps/finicky/src/main.m
+++ b/apps/finicky/src/main.m
@@ -2,14 +2,75 @@
 #include "util/info.h"
 #import <Cocoa/Cocoa.h>
 #import <ApplicationServices/ApplicationServices.h>
+#import <AuthenticationServices/AuthenticationServices.h>
 #import <stdlib.h>
 #import <unistd.h>
 
 #import "window/window.h"  // For ShowWindow()
 
+@interface FinickyAuthenticationSessionHandler : NSObject<ASWebAuthenticationSessionWebBrowserSessionHandling>
+@property (nonatomic, strong) NSMutableDictionary<NSUUID *, ASWebAuthenticationSessionRequest *> *requests;
+- (BOOL)completeRequestWithCallbackURL:(NSURL *)url;
+@end
+
+@implementation FinickyAuthenticationSessionHandler
+
+- (instancetype)init {
+    self = [super init];
+    if (self) {
+        _requests = [[NSMutableDictionary alloc] init];
+    }
+    return self;
+}
+
+- (void)beginHandlingWebAuthenticationSessionRequest:(ASWebAuthenticationSessionRequest *)request {
+    if (!request.URL) {
+        NSError *error = [NSError errorWithDomain:@"se.johnste.finicky.authentication"
+                                             code:1
+                                         userInfo:@{NSLocalizedDescriptionKey: @"Authentication request did not include a URL"}];
+        [request cancelWithError:error];
+        return;
+    }
+
+    self.requests[request.UUID] = request;
+    HandleURL((char *)[[request.URL absoluteString] UTF8String], NULL, NULL, NULL, NULL, false);
+}
+
+- (void)cancelWebAuthenticationSessionRequest:(ASWebAuthenticationSessionRequest *)request {
+    [self.requests removeObjectForKey:request.UUID];
+}
+
+- (BOOL)completeRequestWithCallbackURL:(NSURL *)url {
+    if (!url.scheme) {
+        return NO;
+    }
+
+    for (NSUUID *uuid in [self.requests allKeys]) {
+        ASWebAuthenticationSessionRequest *request = self.requests[uuid];
+        NSString *callbackURLScheme = request.callbackURLScheme;
+        if (callbackURLScheme.length == 0) {
+            continue;
+        }
+        if ([callbackURLScheme caseInsensitiveCompare:@"http"] == NSOrderedSame ||
+            [callbackURLScheme caseInsensitiveCompare:@"https"] == NSOrderedSame) {
+            continue;
+        }
+        if ([url.scheme caseInsensitiveCompare:callbackURLScheme] == NSOrderedSame) {
+            [request completeWithCallbackURL:url];
+            [self.requests removeObjectForKey:uuid];
+            return YES;
+        }
+    }
+
+    return NO;
+}
+
+@end
+
 // Extend BrowseAppDelegate to hold a status item and declare menu action
 @interface BrowseAppDelegate ()
 @property (nonatomic, strong) NSStatusItem *statusItem;
+@property (nonatomic, strong) FinickyAuthenticationSessionHandler *authenticationSessionHandler;
 - (void)showWindowAction:(id)sender;
 @end
 
@@ -30,16 +91,17 @@
 - (void)applicationDidFinishLaunching:(NSNotification *)notification {
     [self terminateOtherInstances];
 
+    bool launchedByAuthenticationServices = [ASWebAuthenticationSessionWebBrowserSessionManager sharedManager].wasLaunchedByAuthenticationServices;
     bool openWindow = self.forceOpenWindow;
     if (!openWindow) {
         // Even if we aren't forcing the window to open, we still want to open it if didn't receive a URL
-        openWindow = !self.receivedURL;
+        openWindow = !self.receivedURL && !launchedByAuthenticationServices;
     }
 
     // Only show menu item if the option is enabled, and we either didn't receive a URL or we are keeping
     // the application running. We don't want to show the icon if Finicky is just receiving a url to open
     // and is expected to exit after
-    if (self.showMenuItem && (self.keepRunning || !self.receivedURL)) {
+    if (self.showMenuItem && (self.keepRunning || (!self.receivedURL && !launchedByAuthenticationServices))) {
         [self createStatusItem];
     }
 
@@ -162,6 +224,9 @@
     [appleEventManager setEventHandler:self
                     andSelector:@selector(handleGetURLEvent:withReplyEvent:)
                     forEventClass:kInternetEventClass andEventID:kAEGetURL];
+
+    self.authenticationSessionHandler = [[FinickyAuthenticationSessionHandler alloc] init];
+    [ASWebAuthenticationSessionWebBrowserSessionManager sharedManager].sessionHandler = self.authenticationSessionHandler;
 }
 
 - (bool)application:(NSApplication *)sender openFile:(NSString *)filename {
@@ -185,12 +250,18 @@
     // Get the application that opened the URL, if available
     int32_t pid = [[event attributeDescriptorForKeyword:keySenderPIDAttr] int32Value];
     NSRunningApplication *application = [NSRunningApplication runningApplicationWithProcessIdentifier:pid];
-    const char *url = [[[event paramDescriptorForKeyword:keyDirectObject] stringValue] UTF8String];
+    NSString *urlString = [[event paramDescriptorForKeyword:keyDirectObject] stringValue];
+    const char *url = [urlString UTF8String];
     const char *name = NULL;
     const char *bundleId = NULL;
     const char *path = NULL;
 
     self.receivedURL = true;
+
+    NSURL *eventURL = [NSURL URLWithString:urlString];
+    if ([self.authenticationSessionHandler completeRequestWithCallbackURL:eventURL]) {
+        return;
+    }
 
     NSRunningApplication *frontApp = [[NSWorkspace sharedWorkspace] frontmostApplication];
 
@@ -247,6 +318,10 @@
     NSURL *url = userActivity.webpageURL;
     if (!url) {
         return false;
+    }
+
+    if ([self.authenticationSessionHandler completeRequestWithCallbackURL:url]) {
+        return true;
     }
 
     HandleURL((char*)[[url absoluteString] UTF8String], NULL, NULL, NULL, NULL, false);


### PR DESCRIPTION
⚠️ Still in progress as some flow don't work yet.

@johnste You maybe the one that may finish this, I cannot make this work locally, maybe this related to this constraint : https://bugzilla.mozilla.org/show_bug.cgi?id=1921535#c10

> testing with a third-party app requires Firefox to be “signed using production entitlements” and to have only one install with that bundle ID.

Since I'm signing this adhoc because i don;t have a developer account, this doesn't appear to work properly.

By the way I created this app (the archive contains sources only, so you'll have to build it), unsure if this is that useful: [finicky-auth-session-test-source.tar.gz](https://github.com/user-attachments/files/27804014/finicky-auth-session-test-source.tar.gz)


----

Apps like Slack and Claude Desktop use `ASWebAuthenticationSession` for SSO/OAuth sign-in flows. Those requests do not go through the normal http/https default-browser `Launch Services` path; macOS only forwards them to the default browser if it declares web authentication session support in `Info.plist`. Without that declaration, the system falls back to Safari before Finicky can apply any routing rules.

https://developer.apple.com/documentation/authenticationservices/supporting-single-sign-on-in-a-web-browser-app#Declare-the-Session-Handling-Capability

This declares Finicky as an `ASWebAuthenticationSession`-capable browser and register a session handler that forwards incoming authentication URLs through the existing URL handling pipeline.

However, it does not declare ephemeral browser session support (`EphemeralBrowserSessionIsSupported`). Indeed, Finicky routes URLs to another browser rather than owning the browsing context itself, so it cannot reliably guarantee that cookies, storage, or profile state are isolated for requests where `AuthenticationServices` asks for an ephemeral session. 

At this time, advertising only the base capability should be the minimal and honest thing to do, and this choice can be re-evaluated if this becomes an issue.

Should fix #405

----

Note, I'm not sure how to unit test that. The integration point `main.m` is not, and this part rely on macOs Launch Services.