### PR TITLE
Hide Window on start config option

### DIFF
--- a/apps/finicky/assets/Info.plist
+++ b/apps/finicky/assets/Info.plist
@@ -17,9 +17,9 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>4.4.0-alpha</string>
+    <string>4.4.0-alpha+suppress-window</string>
     <key>CFBundleVersion</key>
-    <string>4.4.0-alpha</string>
+    <string>4.4.0-alpha+suppress-window</string>
     <key>CFBundleIconFile</key>
     <string>finicky.icns</string>
     <key>LSUIElement</key>

--- a/apps/finicky/assets/Info.plist
+++ b/apps/finicky/assets/Info.plist
@@ -17,9 +17,9 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>4.4.0-alpha+suppress-window</string>
+    <string>4.4.0-alpha</string>
     <key>CFBundleVersion</key>
-    <string>4.4.0-alpha+suppress-window</string>
+    <string>4.4.0-alpha</string>
     <key>CFBundleIconFile</key>
     <string>finicky.icns</string>
     <key>LSUIElement</key>

--- a/apps/finicky/src/config/vm.go
+++ b/apps/finicky/src/config/vm.go
@@ -17,11 +17,11 @@ type VM struct {
 
 // ConfigOptions holds the values of all runtime config options.
 type ConfigOptions struct {
-	KeepRunning     bool
-	HideIcon        bool
-	SuppressWindow  bool
-	LogRequests     bool
-	CheckForUpdates bool
+	KeepRunning       bool
+	HideIcon          bool
+	HideWindowOnStart bool
+	LogRequests       bool
+	CheckForUpdates   bool
 }
 
 // ConfigState represents the current state of the configuration
@@ -155,21 +155,21 @@ func (vm *VM) SetIsJSConfig(v bool) {
 // Safe to call on a nil VM — returns defaults in that case.
 func (vm *VM) GetAllConfigOptions() ConfigOptions {
 	defaults := ConfigOptions{
-		KeepRunning:     true,
-		HideIcon:        false,
-		SuppressWindow:  false,
-		LogRequests:     false,
-		CheckForUpdates: true,
+		KeepRunning:       true,
+		HideIcon:          false,
+		HideWindowOnStart: false,
+		LogRequests:       false,
+		CheckForUpdates:   true,
 	}
 	if vm == nil || vm.runtime == nil {
 		return defaults
 	}
 	script := `({
-		keepRunning:     finickyConfigAPI.getOption('keepRunning',     finalConfig, true),
-		hideIcon:        finickyConfigAPI.getOption('hideIcon',        finalConfig, false),
-		suppressWindow:  finickyConfigAPI.getOption('suppressWindow',  finalConfig, false),
-		logRequests:     finickyConfigAPI.getOption('logRequests',     finalConfig, false),
-		checkForUpdates: finickyConfigAPI.getOption('checkForUpdates', finalConfig, true)
+		keepRunning:       finickyConfigAPI.getOption('keepRunning',       finalConfig, true),
+		hideIcon:          finickyConfigAPI.getOption('hideIcon',          finalConfig, false),
+		hideWindowOnStart: finickyConfigAPI.getOption('hideWindowOnStart', finalConfig, false),
+		logRequests:       finickyConfigAPI.getOption('logRequests',       finalConfig, false),
+		checkForUpdates:   finickyConfigAPI.getOption('checkForUpdates',   finalConfig, true)
 	})`
 	val, err := vm.runtime.RunString(script)
 	if err != nil {
@@ -178,11 +178,11 @@ func (vm *VM) GetAllConfigOptions() ConfigOptions {
 	}
 	obj := val.ToObject(vm.runtime)
 	return ConfigOptions{
-		KeepRunning:     obj.Get("keepRunning").ToBoolean(),
-		HideIcon:        obj.Get("hideIcon").ToBoolean(),
-		SuppressWindow:  obj.Get("suppressWindow").ToBoolean(),
-		LogRequests:     obj.Get("logRequests").ToBoolean(),
-		CheckForUpdates: obj.Get("checkForUpdates").ToBoolean(),
+		KeepRunning:       obj.Get("keepRunning").ToBoolean(),
+		HideIcon:          obj.Get("hideIcon").ToBoolean(),
+		HideWindowOnStart: obj.Get("hideWindowOnStart").ToBoolean(),
+		LogRequests:       obj.Get("logRequests").ToBoolean(),
+		CheckForUpdates:   obj.Get("checkForUpdates").ToBoolean(),
 	}
 }
 

--- a/apps/finicky/src/config/vm.go
+++ b/apps/finicky/src/config/vm.go
@@ -19,6 +19,7 @@ type VM struct {
 type ConfigOptions struct {
 	KeepRunning     bool
 	HideIcon        bool
+	SuppressWindow  bool
 	LogRequests     bool
 	CheckForUpdates bool
 }
@@ -156,6 +157,7 @@ func (vm *VM) GetAllConfigOptions() ConfigOptions {
 	defaults := ConfigOptions{
 		KeepRunning:     true,
 		HideIcon:        false,
+		SuppressWindow:  false,
 		LogRequests:     false,
 		CheckForUpdates: true,
 	}
@@ -165,6 +167,7 @@ func (vm *VM) GetAllConfigOptions() ConfigOptions {
 	script := `({
 		keepRunning:     finickyConfigAPI.getOption('keepRunning',     finalConfig, true),
 		hideIcon:        finickyConfigAPI.getOption('hideIcon',        finalConfig, false),
+		suppressWindow:  finickyConfigAPI.getOption('suppressWindow',  finalConfig, false),
 		logRequests:     finickyConfigAPI.getOption('logRequests',     finalConfig, false),
 		checkForUpdates: finickyConfigAPI.getOption('checkForUpdates', finalConfig, true)
 	})`
@@ -177,6 +180,7 @@ func (vm *VM) GetAllConfigOptions() ConfigOptions {
 	return ConfigOptions{
 		KeepRunning:     obj.Get("keepRunning").ToBoolean(),
 		HideIcon:        obj.Get("hideIcon").ToBoolean(),
+		SuppressWindow:  obj.Get("suppressWindow").ToBoolean(),
 		LogRequests:     obj.Get("logRequests").ToBoolean(),
 		CheckForUpdates: obj.Get("checkForUpdates").ToBoolean(),
 	}

--- a/apps/finicky/src/main.go
+++ b/apps/finicky/src/main.go
@@ -449,7 +449,7 @@ func setupVM(cfw *config.ConfigFileWatcher, namespace string) (*config.VM, error
 			slog.Warn("Failed to load rules file", "error", rulesErr)
 		} else {
 			resolver.SetCachedRules(rf)
-			if rf.DefaultBrowser != "" || len(rf.Rules) > 0 {
+			if rf.DefaultBrowser != "" || len(rf.Rules) > 0 || rf.Options != nil {
 				script, scriptErr := rules.ToJSConfigScript(rf, namespace)
 				if scriptErr != nil {
 					return nil, fmt.Errorf("failed to generate config from rules: %v", scriptErr)

--- a/apps/finicky/src/main.go
+++ b/apps/finicky/src/main.go
@@ -249,10 +249,13 @@ func main() {
 	}()
 
 	shouldHideIcon := false
+	suppressWindow := false
 	if vm != nil {
-		shouldHideIcon = vm.GetAllConfigOptions().HideIcon
+		opts := vm.GetAllConfigOptions()
+		shouldHideIcon = opts.HideIcon
+		suppressWindow = opts.SuppressWindow
 	}
-	C.RunApp(C.bool(forceWindowOpen), C.bool(!shouldHideIcon), C.bool(shouldKeepRunning))
+	C.RunApp(C.bool(forceWindowOpen), C.bool(!shouldHideIcon), C.bool(shouldKeepRunning), C.bool(suppressWindow))
 }
 
 func handleRuntimeError(err error) {

--- a/apps/finicky/src/main.go
+++ b/apps/finicky/src/main.go
@@ -249,13 +249,13 @@ func main() {
 	}()
 
 	shouldHideIcon := false
-	suppressWindow := false
+	hideWindowOnStart := false
 	if vm != nil {
 		opts := vm.GetAllConfigOptions()
 		shouldHideIcon = opts.HideIcon
-		suppressWindow = opts.SuppressWindow
+		hideWindowOnStart = opts.HideWindowOnStart
 	}
-	C.RunApp(C.bool(forceWindowOpen), C.bool(!shouldHideIcon), C.bool(shouldKeepRunning), C.bool(suppressWindow))
+	C.RunApp(C.bool(forceWindowOpen), C.bool(!shouldHideIcon), C.bool(shouldKeepRunning), C.bool(hideWindowOnStart))
 }
 
 func handleRuntimeError(err error) {
@@ -487,11 +487,11 @@ func setupVM(cfw *config.ConfigFileWatcher, namespace string) (*config.VM, error
 		"configPath":     util.ShortenPath(configInfo.ConfigPath),
 		"isJSConfig":     newVM.IsJSConfig(),
 		"options": map[string]interface{}{
-			"keepRunning":     opts.KeepRunning,
-			"hideIcon":        opts.HideIcon,
-			"suppressWindow":  opts.SuppressWindow,
-			"logRequests":     opts.LogRequests,
-			"checkForUpdates": opts.CheckForUpdates,
+			"keepRunning":       opts.KeepRunning,
+			"hideIcon":          opts.HideIcon,
+			"hideWindowOnStart": opts.HideWindowOnStart,
+			"logRequests":       opts.LogRequests,
+			"checkForUpdates":   opts.CheckForUpdates,
 		},
 	})
 

--- a/apps/finicky/src/main.go
+++ b/apps/finicky/src/main.go
@@ -489,6 +489,7 @@ func setupVM(cfw *config.ConfigFileWatcher, namespace string) (*config.VM, error
 		"options": map[string]interface{}{
 			"keepRunning":     opts.KeepRunning,
 			"hideIcon":        opts.HideIcon,
+			"suppressWindow":  opts.SuppressWindow,
 			"logRequests":     opts.LogRequests,
 			"checkForUpdates": opts.CheckForUpdates,
 		},

--- a/apps/finicky/src/main.h
+++ b/apps/finicky/src/main.h
@@ -20,13 +20,13 @@ extern char* GetCurrentConfigPath();
     @property (nonatomic) bool receivedURL;
     @property (nonatomic) bool keepRunning;
     @property (nonatomic) bool showMenuItem;
-    @property (nonatomic) bool suppressWindow;
-    - (instancetype)initWithForceOpenWindow:(bool)forceOpenWindow initShow:(bool)showMenuItem keepRunning:(bool)keepRunning suppressWindow:(bool)suppressWindow;
+    @property (nonatomic) bool hideWindowOnStart;
+    - (instancetype)initWithForceOpenWindow:(bool)forceOpenWindow initShow:(bool)showMenuItem keepRunning:(bool)keepRunning hideWindowOnStart:(bool)hideWindowOnStart;
     - (void)handleGetURLEvent:(NSAppleEventDescriptor *) event withReplyEvent:(NSAppleEventDescriptor *)replyEvent;
     - (bool)application:(NSApplication *)sender openFile:(NSString *)filename;
 @end
 #endif
 
-void RunApp(bool forceOpenWindow, bool showStatusItem, bool keepRunning, bool suppressWindow);
+void RunApp(bool forceOpenWindow, bool showStatusItem, bool keepRunning, bool hideWindowOnStart);
 
 #endif /* MAIN_H */

--- a/apps/finicky/src/main.h
+++ b/apps/finicky/src/main.h
@@ -20,12 +20,13 @@ extern char* GetCurrentConfigPath();
     @property (nonatomic) bool receivedURL;
     @property (nonatomic) bool keepRunning;
     @property (nonatomic) bool showMenuItem;
-    - (instancetype)initWithForceOpenWindow:(bool)forceOpenWindow initShow:(bool)showMenuItem keepRunning:(bool)keepRunning;
+    @property (nonatomic) bool suppressWindow;
+    - (instancetype)initWithForceOpenWindow:(bool)forceOpenWindow initShow:(bool)showMenuItem keepRunning:(bool)keepRunning suppressWindow:(bool)suppressWindow;
     - (void)handleGetURLEvent:(NSAppleEventDescriptor *) event withReplyEvent:(NSAppleEventDescriptor *)replyEvent;
     - (bool)application:(NSApplication *)sender openFile:(NSString *)filename;
 @end
 #endif
 
-void RunApp(bool forceOpenWindow, bool showStatusItem, bool keepRunning);
+void RunApp(bool forceOpenWindow, bool showStatusItem, bool keepRunning, bool suppressWindow);
 
 #endif /* MAIN_H */

--- a/apps/finicky/src/main.m
+++ b/apps/finicky/src/main.m
@@ -7,13 +7,6 @@
 
 #import "window/window.h"  // For ShowWindow()
 
-// On a cold launch, the GetURL/openFile Apple Event that Finicky was started to
-// handle is not guaranteed to have been delivered by the time
-// applicationDidFinishLaunching: runs. We defer the auto-open-window decision by
-// this much so a pending URL event has a chance to set receivedURL first,
-// otherwise the config window briefly flashes before the browser launches.
-static const double kWindowAutoOpenDelaySeconds = 0.2;
-
 // Extend BrowseAppDelegate to hold a status item and declare menu action
 @interface BrowseAppDelegate ()
 @property (nonatomic, strong) NSStatusItem *statusItem;
@@ -22,13 +15,13 @@ static const double kWindowAutoOpenDelaySeconds = 0.2;
 
 @implementation BrowseAppDelegate
 
-- (instancetype)initWithForceOpenWindow:(bool)forceOpenWindow initShow:(bool)showMenuItem keepRunning:(bool)keepRunning suppressWindow:(bool)suppressWindow {
+- (instancetype)initWithForceOpenWindow:(bool)forceOpenWindow initShow:(bool)showMenuItem keepRunning:(bool)keepRunning hideWindowOnStart:(bool)hideWindowOnStart {
     self = [super init];
     if (self) {
         _forceOpenWindow = forceOpenWindow;
         _showMenuItem = showMenuItem;
         _keepRunning = keepRunning;
-        _suppressWindow = suppressWindow;
+        _hideWindowOnStart = hideWindowOnStart;
         _receivedURL = false;
     }
     return self;
@@ -38,30 +31,21 @@ static const double kWindowAutoOpenDelaySeconds = 0.2;
 - (void)applicationDidFinishLaunching:(NSNotification *)notification {
     [self terminateOtherInstances];
 
-    if (self.forceOpenWindow) {
-        // The window was explicitly requested (e.g. via --window), so there's no
-        // need to wait on a possible incoming URL — show it right away.
-        if (self.showMenuItem) {
-            [self createStatusItem];
-        }
-        QueueWindowDisplay(true);
-        return;
+    bool openWindow = self.forceOpenWindow;
+    if (!openWindow) {
+        // Open the window on launch unless we received a URL to handle, or the
+        // user opted out of the automatic launch window via hideWindowOnStart.
+        openWindow = !self.receivedURL && !self.hideWindowOnStart;
     }
 
-    // Defer the auto-open decision so a URL event delivered slightly after launch
-    // suppresses the window instead of racing it (see kWindowAutoOpenDelaySeconds).
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(kWindowAutoOpenDelaySeconds * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-        // Only show menu item if the option is enabled, and we either didn't receive a URL or we are keeping
-        // the application running. We don't want to show the icon if Finicky is just receiving a url to open
-        // and is expected to exit after
-        if (self.showMenuItem && (self.keepRunning || !self.receivedURL)) {
-            [self createStatusItem];
-        }
+    // Only show menu item if the option is enabled, and we either didn't receive a URL or we are keeping
+    // the application running. We don't want to show the icon if Finicky is just receiving a url to open
+    // and is expected to exit after
+    if (self.showMenuItem && (self.keepRunning || !self.receivedURL)) {
+        [self createStatusItem];
+    }
 
-        // Open the window only if we didn't end up receiving a URL to handle,
-        // unless the user opted out of the automatic window entirely.
-        QueueWindowDisplay(!self.receivedURL && !self.suppressWindow);
-    });
+    QueueWindowDisplay(openWindow);
 }
 
 // Ensure only one Finicky process is running. macOS's Launch Services normally
@@ -288,12 +272,12 @@ static const double kWindowAutoOpenDelaySeconds = 0.2;
 
 @end
 
-void RunApp(bool forceOpenWindow, bool showStatusItem, bool keepRunning, bool suppressWindow) {
+void RunApp(bool forceOpenWindow, bool showStatusItem, bool keepRunning, bool hideWindowOnStart) {
     @autoreleasepool {
         // Initialize on the main thread directly, not async
         [NSApplication sharedApplication];
 
-        BrowseAppDelegate *app = [[BrowseAppDelegate alloc] initWithForceOpenWindow:forceOpenWindow initShow:showStatusItem keepRunning:keepRunning suppressWindow:suppressWindow];
+        BrowseAppDelegate *app = [[BrowseAppDelegate alloc] initWithForceOpenWindow:forceOpenWindow initShow:showStatusItem keepRunning:keepRunning hideWindowOnStart:hideWindowOnStart];
         [NSApp setDelegate:app];
 
         [NSApp finishLaunching];

--- a/apps/finicky/src/main.m
+++ b/apps/finicky/src/main.m
@@ -22,12 +22,13 @@ static const double kWindowAutoOpenDelaySeconds = 0.2;
 
 @implementation BrowseAppDelegate
 
-- (instancetype)initWithForceOpenWindow:(bool)forceOpenWindow initShow:(bool)showMenuItem keepRunning:(bool)keepRunning {
+- (instancetype)initWithForceOpenWindow:(bool)forceOpenWindow initShow:(bool)showMenuItem keepRunning:(bool)keepRunning suppressWindow:(bool)suppressWindow {
     self = [super init];
     if (self) {
         _forceOpenWindow = forceOpenWindow;
         _showMenuItem = showMenuItem;
         _keepRunning = keepRunning;
+        _suppressWindow = suppressWindow;
         _receivedURL = false;
     }
     return self;
@@ -57,8 +58,9 @@ static const double kWindowAutoOpenDelaySeconds = 0.2;
             [self createStatusItem];
         }
 
-        // Open the window only if we didn't end up receiving a URL to handle.
-        QueueWindowDisplay(!self.receivedURL);
+        // Open the window only if we didn't end up receiving a URL to handle,
+        // unless the user opted out of the automatic window entirely.
+        QueueWindowDisplay(!self.receivedURL && !self.suppressWindow);
     });
 }
 
@@ -275,12 +277,12 @@ static const double kWindowAutoOpenDelaySeconds = 0.2;
 
 @end
 
-void RunApp(bool forceOpenWindow, bool showStatusItem, bool keepRunning) {
+void RunApp(bool forceOpenWindow, bool showStatusItem, bool keepRunning, bool suppressWindow) {
     @autoreleasepool {
         // Initialize on the main thread directly, not async
         [NSApplication sharedApplication];
 
-        BrowseAppDelegate *app = [[BrowseAppDelegate alloc] initWithForceOpenWindow:forceOpenWindow initShow:showStatusItem keepRunning:keepRunning];
+        BrowseAppDelegate *app = [[BrowseAppDelegate alloc] initWithForceOpenWindow:forceOpenWindow initShow:showStatusItem keepRunning:keepRunning suppressWindow:suppressWindow];
         [NSApp setDelegate:app];
 
         [NSApp finishLaunching];

--- a/apps/finicky/src/main.m
+++ b/apps/finicky/src/main.m
@@ -251,6 +251,17 @@ static const double kWindowAutoOpenDelaySeconds = 0.2;
     // If Finicky isn't frontmost, we take that to mean that the browser should, by default, be opened in the background
     HandleURL((char*)url, (char*)name, (char*)bundleId, (char*)path, windowTitle, !finickyIsInFront);
     free(windowTitle);
+
+    // When routing a URL while we weren't the active app, delivering the Apple
+    // Event can pull Finicky — and any open config window — to the foreground,
+    // briefly flashing it in front of the browser we're about to open. Order the
+    // window back and hand activation back so it stays out of the way. Deferred to
+    // the next runloop turn so it runs after any system-initiated activation.
+    if (!finickyIsInFront) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [NSApp hide:nil];
+        });
+    }
 }
 
 - (bool)application:(NSApplication *)application willContinueUserActivityWithType:(NSString *)userActivityType {

--- a/apps/finicky/src/main.m
+++ b/apps/finicky/src/main.m
@@ -7,6 +7,13 @@
 
 #import "window/window.h"  // For ShowWindow()
 
+// On a cold launch, the GetURL/openFile Apple Event that Finicky was started to
+// handle is not guaranteed to have been delivered by the time
+// applicationDidFinishLaunching: runs. We defer the auto-open-window decision by
+// this much so a pending URL event has a chance to set receivedURL first,
+// otherwise the config window briefly flashes before the browser launches.
+static const double kWindowAutoOpenDelaySeconds = 0.2;
+
 // Extend BrowseAppDelegate to hold a status item and declare menu action
 @interface BrowseAppDelegate ()
 @property (nonatomic, strong) NSStatusItem *statusItem;
@@ -30,20 +37,29 @@
 - (void)applicationDidFinishLaunching:(NSNotification *)notification {
     [self terminateOtherInstances];
 
-    bool openWindow = self.forceOpenWindow;
-    if (!openWindow) {
-        // Even if we aren't forcing the window to open, we still want to open it if didn't receive a URL
-        openWindow = !self.receivedURL;
+    if (self.forceOpenWindow) {
+        // The window was explicitly requested (e.g. via --window), so there's no
+        // need to wait on a possible incoming URL — show it right away.
+        if (self.showMenuItem) {
+            [self createStatusItem];
+        }
+        QueueWindowDisplay(true);
+        return;
     }
 
-    // Only show menu item if the option is enabled, and we either didn't receive a URL or we are keeping
-    // the application running. We don't want to show the icon if Finicky is just receiving a url to open
-    // and is expected to exit after
-    if (self.showMenuItem && (self.keepRunning || !self.receivedURL)) {
-        [self createStatusItem];
-    }
+    // Defer the auto-open decision so a URL event delivered slightly after launch
+    // suppresses the window instead of racing it (see kWindowAutoOpenDelaySeconds).
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(kWindowAutoOpenDelaySeconds * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        // Only show menu item if the option is enabled, and we either didn't receive a URL or we are keeping
+        // the application running. We don't want to show the icon if Finicky is just receiving a url to open
+        // and is expected to exit after
+        if (self.showMenuItem && (self.keepRunning || !self.receivedURL)) {
+            [self createStatusItem];
+        }
 
-    QueueWindowDisplay(openWindow);
+        // Open the window only if we didn't end up receiving a URL to handle.
+        QueueWindowDisplay(!self.receivedURL);
+    });
 }
 
 // Ensure only one Finicky process is running. macOS's Launch Services normally

--- a/apps/finicky/src/main.m
+++ b/apps/finicky/src/main.m
@@ -235,17 +235,6 @@
     // If Finicky isn't frontmost, we take that to mean that the browser should, by default, be opened in the background
     HandleURL((char*)url, (char*)name, (char*)bundleId, (char*)path, windowTitle, !finickyIsInFront);
     free(windowTitle);
-
-    // When routing a URL while we weren't the active app, delivering the Apple
-    // Event can pull Finicky — and any open config window — to the foreground,
-    // briefly flashing it in front of the browser we're about to open. Order the
-    // window back and hand activation back so it stays out of the way. Deferred to
-    // the next runloop turn so it runs after any system-initiated activation.
-    if (!finickyIsInFront) {
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [NSApp hide:nil];
-        });
-    }
 }
 
 - (bool)application:(NSApplication *)application willContinueUserActivityWithType:(NSString *)userActivityType {

--- a/apps/finicky/src/rules/rules.go
+++ b/apps/finicky/src/rules/rules.go
@@ -53,11 +53,11 @@ func (r Rule) MarshalJSON() ([]byte, error) {
 }
 
 type Options struct {
-	KeepRunning     *bool `json:"keepRunning,omitempty"`
-	HideIcon        *bool `json:"hideIcon,omitempty"`
-	SuppressWindow  *bool `json:"suppressWindow,omitempty"`
-	LogRequests     *bool `json:"logRequests,omitempty"`
-	CheckForUpdates *bool `json:"checkForUpdates,omitempty"`
+	KeepRunning       *bool `json:"keepRunning,omitempty"`
+	HideIcon          *bool `json:"hideIcon,omitempty"`
+	HideWindowOnStart *bool `json:"hideWindowOnStart,omitempty"`
+	LogRequests       *bool `json:"logRequests,omitempty"`
+	CheckForUpdates   *bool `json:"checkForUpdates,omitempty"`
 }
 
 type RulesFile struct {
@@ -213,8 +213,8 @@ func ToJSConfigScript(rf RulesFile, namespace string) (string, error) {
 	if rf.Options.HideIcon != nil {
 		opts["hideIcon"] = *rf.Options.HideIcon
 	}
-	if rf.Options.SuppressWindow != nil {
-		opts["suppressWindow"] = *rf.Options.SuppressWindow
+	if rf.Options.HideWindowOnStart != nil {
+		opts["hideWindowOnStart"] = *rf.Options.HideWindowOnStart
 	}
 	if rf.Options.LogRequests != nil {
 		opts["logRequests"] = *rf.Options.LogRequests

--- a/apps/finicky/src/rules/rules.go
+++ b/apps/finicky/src/rules/rules.go
@@ -55,6 +55,7 @@ func (r Rule) MarshalJSON() ([]byte, error) {
 type Options struct {
 	KeepRunning     *bool `json:"keepRunning,omitempty"`
 	HideIcon        *bool `json:"hideIcon,omitempty"`
+	SuppressWindow  *bool `json:"suppressWindow,omitempty"`
 	LogRequests     *bool `json:"logRequests,omitempty"`
 	CheckForUpdates *bool `json:"checkForUpdates,omitempty"`
 }
@@ -211,6 +212,9 @@ func ToJSConfigScript(rf RulesFile, namespace string) (string, error) {
 	}
 	if rf.Options.HideIcon != nil {
 		opts["hideIcon"] = *rf.Options.HideIcon
+	}
+	if rf.Options.SuppressWindow != nil {
+		opts["suppressWindow"] = *rf.Options.SuppressWindow
 	}
 	if rf.Options.LogRequests != nil {
 		opts["logRequests"] = *rf.Options.LogRequests

--- a/apps/finicky/src/rules/rules_test.go
+++ b/apps/finicky/src/rules/rules_test.go
@@ -124,6 +124,24 @@ func TestToJSConfigScript_NamespaceIsUsed(t *testing.T) {
 	}
 }
 
+// A rules file with only an options block (no defaultBrowser or rules) must
+// still emit those options so flags like hideWindowOnStart take effect at
+// startup, falling back to the default browser.
+func TestToJSConfigScript_OptionsOnly(t *testing.T) {
+	hide := true
+	rf := RulesFile{Options: &Options{HideWindowOnStart: &hide}}
+	script, err := ToJSConfigScript(rf, "finickyConfig")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !contains(script, `"hideWindowOnStart":true`) {
+		t.Errorf("expected hideWindowOnStart option in script, got: %s", script)
+	}
+	if !contains(script, "com.apple.Safari") {
+		t.Errorf("expected fallback default browser in script, got: %s", script)
+	}
+}
+
 // ---- Load / Save round-trip ----
 
 func TestLoadSave_RoundTrip(t *testing.T) {

--- a/packages/config-api/src/configSchema.ts
+++ b/packages/config-api/src/configSchema.ts
@@ -136,10 +136,10 @@ const ConfigOptionsSchema = z
     checkForUpdates: z.boolean().optional().describe("Check for updates"),
     keepRunning: z.boolean().optional().describe("Keep the app running"),
     hideIcon: z.boolean().optional().describe("Hide the app icon"),
-    suppressWindow: z
+    hideWindowOnStart: z
       .boolean()
       .optional()
-      .describe("Don't open the window automatically on launch")
+      .describe("Don't open the window when Finicky starts")
   })
   .identifier("ConfigOptions");
 

--- a/packages/config-api/src/configSchema.ts
+++ b/packages/config-api/src/configSchema.ts
@@ -135,7 +135,11 @@ const ConfigOptionsSchema = z
     logRequests: z.boolean().optional().describe("Log to file on disk"),
     checkForUpdates: z.boolean().optional().describe("Check for updates"),
     keepRunning: z.boolean().optional().describe("Keep the app running"),
-    hideIcon: z.boolean().optional().describe("Hide the app icon")
+    hideIcon: z.boolean().optional().describe("Hide the app icon"),
+    suppressWindow: z
+      .boolean()
+      .optional()
+      .describe("Don't open the window automatically on launch")
   })
   .identifier("ConfigOptions");
 

--- a/packages/finicky-ui/src/pages/StartPage.svelte
+++ b/packages/finicky-ui/src/pages/StartPage.svelte
@@ -30,7 +30,7 @@
   // Local editable state, seeded from rules.json overrides then JS config then defaults
   let keepRunning = rulesFile.options?.keepRunning ?? config.options?.keepRunning ?? true;
   let hideIcon = rulesFile.options?.hideIcon ?? config.options?.hideIcon ?? false;
-  let suppressWindow = rulesFile.options?.suppressWindow ?? config.options?.suppressWindow ?? false;
+  let hideWindowOnStart = rulesFile.options?.hideWindowOnStart ?? config.options?.hideWindowOnStart ?? false;
   let logRequests = rulesFile.options?.logRequests ?? config.options?.logRequests ?? false;
   let checkForUpdates = rulesFile.options?.checkForUpdates ?? config.options?.checkForUpdates ?? true;
 
@@ -46,7 +46,7 @@
   $: {
     keepRunning = rulesFile.options?.keepRunning ?? config.options?.keepRunning ?? true;
     hideIcon = rulesFile.options?.hideIcon ?? config.options?.hideIcon ?? false;
-    suppressWindow = rulesFile.options?.suppressWindow ?? config.options?.suppressWindow ?? false;
+    hideWindowOnStart = rulesFile.options?.hideWindowOnStart ?? config.options?.hideWindowOnStart ?? false;
     logRequests = rulesFile.options?.logRequests ?? config.options?.logRequests ?? false;
     checkForUpdates = rulesFile.options?.checkForUpdates ?? config.options?.checkForUpdates ?? true;
     defaultBrowser = isJSConfig ? (config.defaultBrowser ?? "") : (rulesFile.defaultBrowser || SAFARI);
@@ -66,7 +66,7 @@
         ...rulesFile,
         defaultBrowser,
         defaultProfile,
-        options: { keepRunning, hideIcon, suppressWindow, logRequests, checkForUpdates },
+        options: { keepRunning, hideIcon, hideWindowOnStart, logRequests, checkForUpdates },
       },
     });
   }
@@ -81,7 +81,7 @@
           ...rulesFile,
           defaultBrowser,
           defaultProfile,
-          options: { keepRunning, hideIcon, suppressWindow, logRequests, checkForUpdates },
+          options: { keepRunning, hideIcon, hideWindowOnStart, logRequests, checkForUpdates },
         },
       });
     }, SAVE_DEBOUNCE);
@@ -167,9 +167,9 @@
         onchange={scheduleSave}
       />
       <OptionRow
-        label="Don't open window"
-        hint="Never open the window automatically on launch"
-        bind:checked={suppressWindow}
+        label="Hide window on start"
+        hint="Don't open the window when Finicky starts"
+        bind:checked={hideWindowOnStart}
         locked={isJSConfig}
         onLockedClick={onLockedClick}
         onchange={scheduleSave}

--- a/packages/finicky-ui/src/pages/StartPage.svelte
+++ b/packages/finicky-ui/src/pages/StartPage.svelte
@@ -30,6 +30,7 @@
   // Local editable state, seeded from rules.json overrides then JS config then defaults
   let keepRunning = rulesFile.options?.keepRunning ?? config.options?.keepRunning ?? true;
   let hideIcon = rulesFile.options?.hideIcon ?? config.options?.hideIcon ?? false;
+  let suppressWindow = rulesFile.options?.suppressWindow ?? config.options?.suppressWindow ?? false;
   let logRequests = rulesFile.options?.logRequests ?? config.options?.logRequests ?? false;
   let checkForUpdates = rulesFile.options?.checkForUpdates ?? config.options?.checkForUpdates ?? true;
 
@@ -45,6 +46,7 @@
   $: {
     keepRunning = rulesFile.options?.keepRunning ?? config.options?.keepRunning ?? true;
     hideIcon = rulesFile.options?.hideIcon ?? config.options?.hideIcon ?? false;
+    suppressWindow = rulesFile.options?.suppressWindow ?? config.options?.suppressWindow ?? false;
     logRequests = rulesFile.options?.logRequests ?? config.options?.logRequests ?? false;
     checkForUpdates = rulesFile.options?.checkForUpdates ?? config.options?.checkForUpdates ?? true;
     defaultBrowser = isJSConfig ? (config.defaultBrowser ?? "") : (rulesFile.defaultBrowser || SAFARI);
@@ -64,7 +66,7 @@
         ...rulesFile,
         defaultBrowser,
         defaultProfile,
-        options: { keepRunning, hideIcon, logRequests, checkForUpdates },
+        options: { keepRunning, hideIcon, suppressWindow, logRequests, checkForUpdates },
       },
     });
   }
@@ -79,7 +81,7 @@
           ...rulesFile,
           defaultBrowser,
           defaultProfile,
-          options: { keepRunning, hideIcon, logRequests, checkForUpdates },
+          options: { keepRunning, hideIcon, suppressWindow, logRequests, checkForUpdates },
         },
       });
     }, SAVE_DEBOUNCE);
@@ -160,6 +162,14 @@
         label="Hide icon"
         hint="Hide menu bar icon"
         bind:checked={hideIcon}
+        locked={isJSConfig}
+        onLockedClick={onLockedClick}
+        onchange={scheduleSave}
+      />
+      <OptionRow
+        label="Don't open window"
+        hint="Never open the window automatically on launch"
+        bind:checked={suppressWindow}
         locked={isJSConfig}
         onLockedClick={onLockedClick}
         onchange={scheduleSave}

--- a/packages/finicky-ui/src/types.ts
+++ b/packages/finicky-ui/src/types.ts
@@ -7,6 +7,7 @@ export interface Rule {
 export interface ConfigOptions {
   keepRunning: boolean;
   hideIcon: boolean;
+  suppressWindow: boolean;
   logRequests: boolean;
   checkForUpdates: boolean;
 }

--- a/packages/finicky-ui/src/types.ts
+++ b/packages/finicky-ui/src/types.ts
@@ -7,7 +7,7 @@ export interface Rule {
 export interface ConfigOptions {
   keepRunning: boolean;
   hideIcon: boolean;
-  suppressWindow: boolean;
+  hideWindowOnStart: boolean;
   logRequests: boolean;
   checkForUpdates: boolean;
 }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -62,6 +62,13 @@ build_arch() {
         -o ../build/${APP_NAME}/Contents/MacOS/Finicky
 }
 
+# Remove stale .app bundles from previous builds. Without this, a second local
+# build fails because `mv Finicky-arm64.app Finicky.app` nests the new bundle
+# inside the existing Finicky.app directory instead of replacing it.
+rm -rf apps/finicky/build/Finicky.app \
+       apps/finicky/build/Finicky-arm64.app \
+       apps/finicky/build/Finicky-amd64.app
+
 if [ "${BUILD_UNIVERSAL:-0}" = "1" ]; then
     build_arch arm64
     build_arch amd64


### PR DESCRIPTION
This should help address the issue mentioned in #495

If you close the Finicky window, it doesn't appear when opening URLs. So if we also avoid opening the window on app start, the window stops being a problem

This PR adds a hideWindowOnStart option that does exactly that: when enabled, Finicky won't open its window on launch. The default behavior is unchanged.

Tested it locally, looks good

Fixes #495

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Hide window on start" option in config and UI, and applied at app startup.

* **Bug Fixes**
  * Suppresses the launch window on startup when the new option is enabled (avoids brief unwanted window).

* **Tests**
  * Added test ensuring options-only configs (including hide-window) are emitted correctly.

* **Chores**
  * Remove stale app bundles before macOS build to avoid nested .app issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->