### PR TITLE
fix: resolve Firefox/Chromium profiles when the browser is configured by path

### DIFF
--- a/apps/finicky/src/browser/launcher.go
+++ b/apps/finicky/src/browser/launcher.go
@@ -147,6 +147,25 @@ func LaunchBrowser(config BrowserConfig, dryRun bool, openInBackgroundByDefault 
 	return nil
 }
 
+// findBrowserInfo locates a browser in browsers.json by bundle ID, app name, or
+// an app bundle path (e.g. "/Applications/Firefox.app"). For a path, the
+// basename without the ".app" suffix is matched against the app name, so profile
+// detection works for configs that specify the browser by path (appType
+// "path"), not just by bundle ID or app name.
+func findBrowserInfo(browsersJson []browserInfo, identifier string) *browserInfo {
+	base := identifier
+	if strings.HasSuffix(base, ".app") {
+		base = strings.TrimSuffix(filepath.Base(base), ".app")
+	}
+	for i := range browsersJson {
+		b := &browsersJson[i]
+		if b.ID == identifier || b.AppName == identifier || (base != "" && b.AppName == base) {
+			return b
+		}
+	}
+	return nil
+}
+
 func resolveBrowserProfileArgs(identifier string, profile string) ([]string, bool) {
 	var browsersJson []browserInfo
 	if err := json.Unmarshal(browsersJsonData, &browsersJson); err != nil {
@@ -154,15 +173,7 @@ func resolveBrowserProfileArgs(identifier string, profile string) ([]string, boo
 		return nil, false
 	}
 
-	// Try to find matching browser by bundle ID
-	var matchedBrowser *browserInfo
-	for _, browser := range browsersJson {
-		if browser.ID == identifier || browser.AppName == identifier {
-			matchedBrowser = &browser
-			break
-		}
-	}
-
+	matchedBrowser := findBrowserInfo(browsersJson, identifier)
 	if matchedBrowser == nil {
 		return nil, false
 	}
@@ -347,14 +358,7 @@ func GetProfilesForBrowser(identifier string) []string {
 		return []string{}
 	}
 
-	var matchedBrowser *browserInfo
-	for i := range browsersJson {
-		if browsersJson[i].ID == identifier || browsersJson[i].AppName == identifier {
-			matchedBrowser = &browsersJson[i]
-			break
-		}
-	}
-
+	matchedBrowser := findBrowserInfo(browsersJson, identifier)
 	if matchedBrowser == nil {
 		return []string{}
 	}

--- a/apps/finicky/src/browser/launcher_test.go
+++ b/apps/finicky/src/browser/launcher_test.go
@@ -1,0 +1,46 @@
+package browser
+
+import "testing"
+
+func TestFindBrowserInfo(t *testing.T) {
+	browsers := []browserInfo{
+		{ConfigDirRelative: "Firefox", ID: "org.mozilla.firefox", AppName: "Firefox", Type: "Firefox"},
+		{ConfigDirRelative: "Firefox", ID: "org.mozilla.firefoxdeveloperedition", AppName: "Firefox Developer Edition", Type: "Firefox"},
+		{ConfigDirRelative: "zen", ID: "app.zen-browser.zen", AppName: "Zen", Type: "Firefox"},
+		{ConfigDirRelative: "Google/Chrome", ID: "com.google.Chrome", AppName: "Google Chrome", Type: "Chromium"},
+	}
+
+	cases := []struct {
+		name       string
+		identifier string
+		wantID     string // "" means expect no match
+	}{
+		{"by app name", "Firefox", "org.mozilla.firefox"},
+		{"by bundle id", "org.mozilla.firefox", "org.mozilla.firefox"},
+		{"by .app path", "/Applications/Firefox.app", "org.mozilla.firefox"},
+		{"by .app path with spaces", "/Applications/Firefox Developer Edition.app", "org.mozilla.firefoxdeveloperedition"},
+		{"zen by path", "/Applications/Zen.app", "app.zen-browser.zen"},
+		{"chromium by path", "/Applications/Google Chrome.app", "com.google.Chrome"},
+		{"unknown app name", "Safari", ""},
+		{"unknown path", "/Applications/Safari.app", ""},
+		{"path basename must not partial-match", "/Applications/Firefoxxx.app", ""},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := findBrowserInfo(browsers, c.identifier)
+			if c.wantID == "" {
+				if got != nil {
+					t.Fatalf("expected no match for %q, got %q", c.identifier, got.ID)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("expected match %q for %q, got nil", c.wantID, c.identifier)
+			}
+			if got.ID != c.wantID {
+				t.Fatalf("for %q: got %q, want %q", c.identifier, got.ID, c.wantID)
+			}
+		})
+	}
+}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -89,6 +89,9 @@ else
     APP_NAME="Finicky.app"
     # Rename arch build to plain Finicky.app
     build_arch arm64
+    # Remove any stale bundle first; otherwise mv nests the new build inside it
+    # and (with set -e) aborts before installing, silently leaving the old app.
+    rm -rf apps/finicky/build/${APP_NAME}
     mv apps/finicky/build/Finicky-arm64.app apps/finicky/build/${APP_NAME}
     copy_assets ${APP_NAME}
 


### PR DESCRIPTION
## Problem

When a handler specifies the browser by path (`appType: "path"`), e.g.

```js
browser: { name: "/Applications/Firefox.app", appType: "path", profile: "Work" }
```

the requested profile is silently ignored and the browser opens without it.

For Firefox the symptom is worse: with no profile argument, the launch falls into Firefox's default profile selection, which on recent versions (the new multi-profile feature — `ShowSelector` in `profiles.ini`) pops the **profile picker** window on every link instead of opening the chosen profile.

## Root cause

`resolveBrowserProfileArgs` (and `GetProfilesForBrowser`) look up the browser in `browsers.json` by **bundle ID or app name only**:

```go
if browser.ID == identifier || browser.AppName == identifier { ... }
```

With `appType: "path"` the identifier is the bundle path (`/Applications/Firefox.app`), which matches neither `org.mozilla.firefox` nor `Firefox`, so no match is found and no profile argument is emitted.

## Fix

Add `findBrowserInfo`, which additionally matches an `.app` bundle path by its basename (minus `.app`) against the app name, and use it in both call sites. Profile detection now works for path-based configs for Firefox and Chromium alike. The usual `-P <name>` (Firefox) / `--profile-directory=` (Chromium) argument is emitted as before — which, for Firefox, also keeps the launch out of the default-selection path that triggers the picker.

Behavior for bundle-ID and app-name configs is unchanged.

## Tests

Added `launcher_test.go` covering `findBrowserInfo`: match by app name, bundle ID, and `.app` path (including names with spaces such as "Firefox Developer Edition"), Chromium by path, plus negative cases (unknown app, unknown path, and no partial-prefix match).

## Verified

Built and run locally on macOS (Apple Silicon, Firefox 151): links now open in the configured profile with no profile-picker window, routing into the running per-profile instance as a new tab.

---

The second commit is a small, unrelated build fix: the local `build.sh` path could `mv` a freshly built bundle into a stale `build/Finicky.app` and then abort under `set -e` before installing, silently leaving the old app in place. Happy to split it into its own PR if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved build process issue where stale app bundles could interfere with installation.
  * Enhanced browser profile detection to support app bundle paths in addition to existing identifier formats.

* **Tests**
  * Added comprehensive test suite for browser identification logic, covering various identifier types and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->