### PR TITLE
fix(build): use rm -rf so a clean first build doesn't fail

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -90,7 +90,7 @@ else
     # Rename arch build to plain Finicky.app
     build_arch arm64
 
-    rm -r apps/finicky/build/${APP_NAME}
+    rm -rf apps/finicky/build/${APP_NAME}
     mv apps/finicky/build/Finicky-arm64.app apps/finicky/build/${APP_NAME}
     copy_assets ${APP_NAME}
 


### PR DESCRIPTION
## Problem

On a fresh checkout, running `./scripts/build.sh` (local native-arch path) fails on its **first** run:

```
rm: apps/finicky/build/Finicky.app: No such file or directory
```

The local build path does:

```sh
build_arch arm64
rm -r apps/finicky/build/${APP_NAME}   # Finicky.app
mv apps/finicky/build/Finicky-arm64.app apps/finicky/build/${APP_NAME}
```

Because the script runs under `set -e` and `apps/finicky/build/Finicky.app` does not exist yet on a first build, `rm -r` errors out and aborts the build before the `mv`/asset copy. It only works once a previous build has already created the directory.

## Fix

Use `rm -rf` so the removal is a harmless no-op when the directory doesn't exist yet. Subsequent builds are unaffected.

## Testing

- Clean checkout → `./scripts/install.sh && ./scripts/build.sh` now completes with `Build complete ✨` on the first run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Made the local build cleanup step more resilient when the target build folder does not exist.
  * Prevents the build script from failing unnecessarily during native-architecture builds while keeping the same cleanup behavior when the folder is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->