### PR TITLE
fix: launch selected Chrome profiles directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Finicky is a macOS application that allows you to set up rules that decide which
 
 - [Installation](#installation)
 - [Basic configuration](#basic-configuration)
+- [Verifying Chrome profile routing](#verifying-chrome-profile-routing)
 - [Configuration](#configuration)
 - [Migrating from Finicky 3](#migrating-from-finicky-3)
 
@@ -70,6 +71,24 @@ export default {
 ```
 
 See the [configuration](#configuration) for all the features Finicky supports.
+
+## Verifying Chrome profile routing
+
+Use an object browser configuration to select a Chrome profile:
+
+```js
+{
+  match: "example.com/*",
+  browser: { name: "Google Chrome", profile: "Work" },
+}
+```
+
+To verify routing without relying on a successful command log:
+
+1. Make a different Chrome profile active.
+2. Open a harmless external URL such as `https://example.com` from a source app covered by the rule.
+3. In the tab that opens, visit `chrome://version` and compare **Profile Path** with the intended profile directory. Chrome profile display names and directory names can differ, for example `Work` and `Profile 1`.
+4. Repeat after making the other profile active. The selected profile path must remain the same.
 
 ## Configuration
 

--- a/apps/finicky/src/browser/browsers.json
+++ b/apps/finicky/src/browser/browsers.json
@@ -30,6 +30,12 @@
     "app_name": "Chromium"
   },
   {
+    "config_dir_relative": "Citro Labs/ego lite",
+    "id": "com.citrolabs.ego.lite",
+    "type": "Chromium",
+    "app_name": "ego lite"
+  },
+  {
     "config_dir_relative": "Microsoft Edge",
     "id": "com.microsoft.edgemac",
     "type": "Chromium",

--- a/apps/finicky/src/browser/launcher.go
+++ b/apps/finicky/src/browser/launcher.go
@@ -9,8 +9,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"slices"
+	"strings"
 
 	"al.essio.dev/pkg/shellescape"
 	"finicky/util"
@@ -40,7 +40,7 @@ type browserInfo struct {
 	Type              string `json:"type"`
 }
 
-func LaunchBrowser(config BrowserConfig, dryRun bool, openInBackgroundByDefault bool) error {
+func LaunchBrowser(config BrowserConfig, dryRun bool, openInBackgroundByDefault bool, restoreSourceApp func(string)) error {
 	if config.AppType == "none" {
 		slog.Info("AppType is 'none', not launching any browser")
 		return nil
@@ -48,55 +48,152 @@ func LaunchBrowser(config BrowserConfig, dryRun bool, openInBackgroundByDefault 
 
 	slog.Info("Starting browser", "name", config.Name, "url", config.URL)
 
-	var openArgs []string
-
-	if config.AppType == "bundleId" {
-		openArgs = []string{"-b", config.Name}
-	} else {
-		openArgs = []string{"-a", config.Name}
+	profileArgs, profileFound := resolveBrowserProfileArgs(config.Name, config.Profile)
+	if config.Profile != "" && !profileFound {
+		return fmt.Errorf("requested browser profile could not be resolved")
 	}
-
-	var openInBackground bool = openInBackgroundByDefault
-
-	if config.OpenInBackground != nil {
-		openInBackground = *config.OpenInBackground
-	}
-
-	if openInBackground {
-		openArgs = append(openArgs, "-g")
-	}
-
-	// Handle profile and custom args
-	profileArgs, ok := resolveBrowserProfileArgs(config.Name, config.Profile)
-	hasCustomArgs := len(config.Args) > 0
-
-	// Add -n flag if profile is used (required for profile switching)
-	if ok {
-		openArgs = append(openArgs, "-n")
-	}
-
-	// Add --args if we have profile args or custom args
-	if ok || hasCustomArgs {
-		if ! slices.Contains(config.Args, "--args") {
-			openArgs = append(openArgs, "--args")
+	openInBackground := shouldOpenInBackground(config, openInBackgroundByDefault)
+	if profileFound {
+		if !openInBackground {
+			restoreSourceApp = nil
 		}
-		// Add profile arguments first if present
-		if ok {
-			openArgs = append(openArgs, profileArgs...)
-		}
-
-		// Add custom args or URL
-		if hasCustomArgs {
-			openArgs = append(openArgs, config.Args...)
-		} else {
-			openArgs = append(openArgs, config.URL)
-		}
-	} else {
-		// No special args, just add the URL
-		openArgs = append(openArgs, config.URL)
+		return launchProfileBrowser(config, dryRun, profileArgs, restoreSourceApp)
 	}
 
+	openArgs := buildOpenArgs(config, openInBackground)
 	cmd := exec.Command("open", openArgs...)
+	return runOpenCommand(cmd, dryRun)
+}
+
+func launchProfileBrowser(config BrowserConfig, dryRun bool, profileArgs []string, restoreSourceApp func(string)) error {
+	bundlePath, err := profileBrowserBundlePath(config)
+	if err != nil {
+		return err
+	}
+	bundleID := ""
+	if restoreSourceApp != nil {
+		bundleID, err = appBundleIdentifier(bundlePath)
+		if err != nil {
+			return err
+		}
+	}
+	executable, err := profileBrowserExecutable(bundlePath)
+	if err != nil {
+		return err
+	}
+
+	cmd := exec.Command(executable, buildProfileLaunchArgs(config, profileArgs)...)
+	prettyCmd := formatCommand(cmd.Path, cmd.Args)
+	if dryRun {
+		slog.Debug("Would run command (dry run)", "command", prettyCmd)
+		return nil
+	}
+
+	slog.Debug("Run command", "command", prettyCmd)
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	if restoreSourceApp != nil {
+		restoreSourceApp(bundleID)
+	}
+
+	go func() {
+		if err := cmd.Wait(); err != nil {
+			slog.Error("Browser process exited with error", "error", err)
+		}
+	}()
+
+	return nil
+}
+
+func profileBrowserExecutable(bundlePath string) (string, error) {
+	executable, err := appBundleExecutablePath(bundlePath)
+	if err != nil {
+		return "", err
+	}
+	info, err := os.Stat(executable)
+	if err != nil {
+		return "", fmt.Errorf("could not find browser executable for profile launch: %w", err)
+	}
+	if info.IsDir() {
+		return "", fmt.Errorf("browser executable for profile launch is a directory")
+	}
+	return executable, nil
+}
+
+func profileBrowserBundlePath(config BrowserConfig) (string, error) {
+	if filepath.Ext(config.Name) == ".app" {
+		return config.Name, nil
+	}
+
+	candidates := []string{filepath.Join("/Applications", config.Name+".app")}
+	if homeDir, err := os.UserHomeDir(); err == nil {
+		candidates = append(candidates, filepath.Join(homeDir, "Applications", config.Name+".app"))
+	}
+	for _, candidate := range candidates {
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate, nil
+		}
+	}
+
+	query := fmt.Sprintf("kMDItemDisplayName == %q", config.Name)
+	if config.AppType == "bundleId" {
+		query = fmt.Sprintf("kMDItemCFBundleIdentifier == %q", config.Name)
+	}
+	output, err := exec.Command("mdfind", query).Output()
+	if err != nil {
+		return "", fmt.Errorf("could not find browser application for profile launch: %w", err)
+	}
+	for _, candidate := range strings.Split(strings.TrimSpace(string(output)), "\n") {
+		if filepath.Ext(candidate) == ".app" {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("could not find browser application for profile launch")
+}
+
+func appBundleExecutablePath(bundlePath string) (string, error) {
+	name, err := appBundleInfoValue(bundlePath, "CFBundleExecutable")
+	if err != nil {
+		return "", err
+	}
+	if name == "" || filepath.Base(name) != name {
+		return "", fmt.Errorf("browser executable metadata is invalid")
+	}
+	return filepath.Join(bundlePath, "Contents", "MacOS", name), nil
+}
+
+func appBundleIdentifier(bundlePath string) (string, error) {
+	return appBundleInfoValue(bundlePath, "CFBundleIdentifier")
+}
+
+func appBundleInfoValue(bundlePath string, key string) (string, error) {
+	infoPath := filepath.Join(bundlePath, "Contents", "Info.plist")
+	output, err := exec.Command("plutil", "-extract", key, "raw", "-o", "-", infoPath).Output()
+	if err != nil {
+		return "", fmt.Errorf("could not read browser bundle metadata: %w", err)
+	}
+	value := strings.TrimSpace(string(output))
+	if value == "" {
+		return "", fmt.Errorf("browser bundle metadata is empty")
+	}
+	return value, nil
+}
+
+func buildProfileLaunchArgs(config BrowserConfig, profileArgs []string) []string {
+	args := append([]string{}, profileArgs...)
+	for _, arg := range config.Args {
+		if arg != "--args" {
+			args = append(args, arg)
+		}
+	}
+	if len(config.Args) == 0 {
+		args = append(args, config.URL)
+	}
+	return args
+}
+
+func runOpenCommand(cmd *exec.Cmd, dryRun bool) error {
 
 	// Pretty print the command with proper escaping
 	prettyCmd := formatCommand(cmd.Path, cmd.Args)
@@ -147,6 +244,37 @@ func LaunchBrowser(config BrowserConfig, dryRun bool, openInBackgroundByDefault 
 	return nil
 }
 
+func shouldOpenInBackground(config BrowserConfig, openInBackgroundByDefault bool) bool {
+	if config.OpenInBackground != nil {
+		return *config.OpenInBackground
+	}
+	return openInBackgroundByDefault
+}
+
+func buildOpenArgs(config BrowserConfig, openInBackground bool) []string {
+	var openArgs []string
+	switch config.AppType {
+	case "bundleId":
+		openArgs = []string{"-b", config.Name}
+	default:
+		openArgs = []string{"-a", config.Name}
+	}
+
+	if openInBackground {
+		openArgs = append(openArgs, "-g")
+	}
+
+	hasCustomArgs := len(config.Args) > 0
+	if hasCustomArgs {
+		if !slices.Contains(config.Args, "--args") {
+			openArgs = append(openArgs, "--args")
+		}
+		return append(openArgs, config.Args...)
+	}
+
+	return append(openArgs, config.URL)
+}
+
 func resolveBrowserProfileArgs(identifier string, profile string) ([]string, bool) {
 	var browsersJson []browserInfo
 	if err := json.Unmarshal(browsersJsonData, &browsersJson); err != nil {
@@ -156,9 +284,9 @@ func resolveBrowserProfileArgs(identifier string, profile string) ([]string, boo
 
 	// Try to find matching browser by bundle ID
 	var matchedBrowser *browserInfo
-	for _, browser := range browsersJson {
-		if browser.ID == identifier || browser.AppName == identifier {
-			matchedBrowser = &browser
+	for i := range browsersJson {
+		if matchesBrowser(browsersJson[i], identifier) {
+			matchedBrowser = &browsersJson[i]
 			break
 		}
 	}
@@ -201,6 +329,13 @@ func resolveBrowserProfileArgs(identifier string, profile string) ([]string, boo
 	}
 
 	return nil, false
+}
+
+func matchesBrowser(browser browserInfo, identifier string) bool {
+	if browser.ID == identifier || browser.AppName == identifier {
+		return true
+	}
+	return filepath.Ext(identifier) == ".app" && strings.TrimSuffix(filepath.Base(identifier), ".app") == browser.AppName
 }
 
 func readFirefoxProfileNames(profilesIniPath string) []string {
@@ -349,7 +484,7 @@ func GetProfilesForBrowser(identifier string) []string {
 
 	var matchedBrowser *browserInfo
 	for i := range browsersJson {
-		if browsersJson[i].ID == identifier || browsersJson[i].AppName == identifier {
+		if matchesBrowser(browsersJson[i], identifier) {
 			matchedBrowser = &browsersJson[i]
 			break
 		}

--- a/apps/finicky/src/browser/launcher_test.go
+++ b/apps/finicky/src/browser/launcher_test.go
@@ -1,0 +1,137 @@
+package browser
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestParseProfilesAcceptsProfileNameAndDirectory(t *testing.T) {
+	localStatePath := filepath.Join(t.TempDir(), "Local State")
+	if err := os.WriteFile(localStatePath, []byte(`{"profile":{"info_cache":{"Profile 1":{"name":"Work Profile"}}}}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, profile := range []string{"Work Profile", "Profile 1"} {
+		got, ok := parseProfiles(localStatePath, profile)
+		if !ok || got != "Profile 1" {
+			t.Fatalf("parseProfiles(%q) = %q, %v; want Profile 1, true", profile, got, ok)
+		}
+	}
+}
+
+func TestBuildProfileLaunchArgsPreservesProfileDirectoryAndURL(t *testing.T) {
+	config := BrowserConfig{
+		Name:    "Google Chrome",
+		AppType: "appName",
+		Profile: "Work Profile",
+		URL:     "https://example.invalid/",
+	}
+
+	got := buildProfileLaunchArgs(config, []string{"--profile-directory=Profile 1"})
+	want := []string{"--profile-directory=Profile 1", "https://example.invalid/"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("buildProfileLaunchArgs() = %#v, want %#v", got, want)
+	}
+}
+
+func TestAppBundleExecutablePathUsesBundleMetadata(t *testing.T) {
+	bundlePath := filepath.Join(t.TempDir(), "Firefox.app")
+	infoPath := filepath.Join(bundlePath, "Contents", "Info.plist")
+	if err := os.MkdirAll(filepath.Dir(infoPath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(infoPath, []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0"><dict><key>CFBundleExecutable</key><string>firefox-bin</string></dict></plist>`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := appBundleExecutablePath(bundlePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(bundlePath, "Contents", "MacOS", "firefox-bin")
+	if got != want {
+		t.Fatalf("appBundleExecutablePath() = %q, want %q", got, want)
+	}
+}
+
+func TestLaunchProfileBrowserUsesProfileArguments(t *testing.T) {
+	bundlePath := filepath.Join(t.TempDir(), "Google Chrome.app")
+	infoPath := filepath.Join(bundlePath, "Contents", "Info.plist")
+	executablePath := filepath.Join(bundlePath, "Contents", "MacOS", "Google Chrome")
+	if err := os.MkdirAll(filepath.Dir(executablePath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(infoPath, []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0"><dict><key>CFBundleExecutable</key><string>Google Chrome</string></dict></plist>`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(executablePath, nil, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := launchProfileBrowser(BrowserConfig{Name: bundlePath}, true, []string{"--profile-directory=Profile 1"}, nil); err != nil {
+		t.Fatalf("launchProfileBrowser() error = %v, want nil", err)
+	}
+}
+
+func TestLaunchProfileBrowserRequestsSourceAppRestore(t *testing.T) {
+	bundlePath := filepath.Join(t.TempDir(), "Google Chrome.app")
+	infoPath := filepath.Join(bundlePath, "Contents", "Info.plist")
+	executablePath := filepath.Join(bundlePath, "Contents", "MacOS", "Google Chrome")
+	if err := os.MkdirAll(filepath.Dir(executablePath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(infoPath, []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0"><dict><key>CFBundleExecutable</key><string>Google Chrome</string><key>CFBundleIdentifier</key><string>com.google.Chrome</string></dict></plist>`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(executablePath, []byte("#!/bin/sh\nexit 0\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	restored := make(chan string, 1)
+	if err := launchProfileBrowser(BrowserConfig{Name: bundlePath}, false, []string{"--profile-directory=Profile 1"}, func(bundleID string) {
+		restored <- bundleID
+	}); err != nil {
+		t.Fatalf("launchProfileBrowser() error = %v, want nil", err)
+	}
+
+	select {
+	case bundleID := <-restored:
+		if bundleID != "com.google.Chrome" {
+			t.Fatalf("restore bundle ID = %q, want com.google.Chrome", bundleID)
+		}
+	default:
+		t.Fatal("profile launch did not request restoring the source application")
+	}
+}
+
+func TestShouldOpenInBackgroundUsesBrowserSetting(t *testing.T) {
+	openInBackground := false
+	if shouldOpenInBackground(BrowserConfig{OpenInBackground: &openInBackground}, true) {
+		t.Fatal("browser setting did not override the default")
+	}
+}
+
+func TestBrowserInfoMatchesApplicationPathWithSpaces(t *testing.T) {
+	browser := browserInfo{ID: "com.google.Chrome", AppName: "Google Chrome"}
+	if !matchesBrowser(browser, "/Applications/Google Chrome.app") {
+		t.Fatal("application path did not match Google Chrome")
+	}
+}
+
+func TestLaunchBrowserRejectsUnresolvedRequestedProfile(t *testing.T) {
+	config := BrowserConfig{
+		Name:    "Unknown Browser",
+		AppType: "appName",
+		Profile: "Work Profile",
+		URL:     "https://example.invalid/",
+	}
+
+	if err := LaunchBrowser(config, true, false, nil); err == nil {
+		t.Fatal("LaunchBrowser() succeeded without the requested profile")
+	}
+}

--- a/apps/finicky/src/browser/launcher_test.go
+++ b/apps/finicky/src/browser/launcher_test.go
@@ -1,6 +1,7 @@
 package browser
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -121,6 +122,25 @@ func TestBrowserInfoMatchesApplicationPathWithSpaces(t *testing.T) {
 	if !matchesBrowser(browser, "/Applications/Google Chrome.app") {
 		t.Fatal("application path did not match Google Chrome")
 	}
+}
+
+func TestEgoLiteIsChromiumProfileBrowser(t *testing.T) {
+	var browsers []browserInfo
+	if err := json.Unmarshal(browsersJsonData, &browsers); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, browser := range browsers {
+		if browser.ID != "com.citrolabs.ego.lite" {
+			continue
+		}
+		if browser.AppName != "ego lite" || browser.Type != "Chromium" || browser.ConfigDirRelative != "Citro Labs/ego lite" {
+			t.Fatalf("Ego Lite browser metadata = %#v", browser)
+		}
+		return
+	}
+
+	t.Fatal("Ego Lite browser metadata is missing")
 }
 
 func TestLaunchBrowserRejectsUnresolvedRequestedProfile(t *testing.T) {

--- a/apps/finicky/src/config/configfiles.go
+++ b/apps/finicky/src/config/configfiles.go
@@ -118,11 +118,19 @@ func (cfw *ConfigFileWatcher) GetConfigPath(log bool) (string, error) {
 	return "", fmt.Errorf("no config file found in any of these locations: %s", strings.Join(configPaths, ", "))
 }
 
+// BundleConfig bundles the active JS config. If none exists at a default path,
+// it returns empty paths so callers can fall back to JSON rules.
 func (cfw *ConfigFileWatcher) BundleConfig() (string, string, error) {
 	configPath, err := cfw.GetConfigPath(true)
 
-	if configPath == "" || err != nil {
+	if err != nil {
+		if cfw.customConfigPath == "" {
+			return "", "", nil
+		}
 		return "", "", err
+	}
+	if configPath == "" {
+		return "", "", nil
 	}
 
 	// Check if we can use cached bundle

--- a/apps/finicky/src/config/configfiles_test.go
+++ b/apps/finicky/src/config/configfiles_test.go
@@ -1,0 +1,33 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestBundleConfigWithoutDefaultConfig(t *testing.T) {
+	cfw := &ConfigFileWatcher{}
+	for _, path := range cfw.GetConfigPaths() {
+		if _, err := os.Stat(path); err == nil {
+			t.Skipf("default config exists at %s", path)
+		}
+	}
+
+	bundlePath, configPath, err := cfw.BundleConfig()
+	if err != nil {
+		t.Fatalf("BundleConfig() returned an error: %v", err)
+	}
+	if bundlePath != "" || configPath != "" {
+		t.Fatalf("BundleConfig() = (%q, %q), want empty paths", bundlePath, configPath)
+	}
+}
+
+func TestBundleConfigMissingCustomConfigReturnsError(t *testing.T) {
+	cfw := &ConfigFileWatcher{customConfigPath: filepath.Join(t.TempDir(), "finicky.js")}
+
+	_, _, err := cfw.BundleConfig()
+	if err == nil {
+		t.Fatal("BundleConfig() returned nil error for a missing custom config")
+	}
+}

--- a/apps/finicky/src/main.go
+++ b/apps/finicky/src/main.go
@@ -26,6 +26,7 @@ import (
 	"runtime"
 	"strings"
 	"time"
+	"unsafe"
 
 	"github.com/dop251/goja"
 )
@@ -39,9 +40,10 @@ type UpdateInfo struct {
 }
 
 type URLInfo struct {
-	URL              string
-	Opener           *resolver.OpenerInfo
-	OpenInBackground bool
+	URL                  string
+	Opener               *resolver.OpenerInfo
+	OpenInBackground     bool
+	SourceApplicationPID int32
 }
 
 type ConfigInfo struct {
@@ -196,7 +198,14 @@ func main() {
 				} else {
 					lastError = nil
 				}
-				if launchErr := browser.LaunchBrowser(*config, dryRun, urlInfo.OpenInBackground); launchErr != nil {
+				var restoreSourceApp func(string)
+				if urlInfo.OpenInBackground && urlInfo.SourceApplicationPID > 0 {
+					restoreSourceApp = func(browserBundleID string) {
+						slog.Debug("Restoring source application after profile launch", "sourceApplicationPID", urlInfo.SourceApplicationPID, "browserBundleID", browserBundleID)
+						restoreFrontmostApplication(urlInfo.SourceApplicationPID, browserBundleID)
+					}
+				}
+				if launchErr := browser.LaunchBrowser(*config, dryRun, urlInfo.OpenInBackground, restoreSourceApp); launchErr != nil {
 					slog.Error("Failed to start browser", "error", launchErr)
 				}
 
@@ -265,7 +274,7 @@ func handleRuntimeError(err error) {
 }
 
 //export HandleURL
-func HandleURL(url *C.char, name *C.char, bundleId *C.char, path *C.char, windowTitle *C.char, openInBackground C.bool) {
+func HandleURL(url *C.char, name *C.char, bundleId *C.char, path *C.char, windowTitle *C.char, openInBackground C.bool, sourceApplicationPID C.int) {
 	var opener resolver.OpenerInfo
 
 	if name != nil && bundleId != nil && path != nil {
@@ -293,10 +302,17 @@ func HandleURL(url *C.char, name *C.char, bundleId *C.char, path *C.char, window
 	}
 
 	urlListener <- URLInfo{
-		URL:              urlString,
-		Opener:           &opener,
-		OpenInBackground: bool(openInBackground),
+		URL:                  urlString,
+		Opener:               &opener,
+		OpenInBackground:     bool(openInBackground),
+		SourceApplicationPID: int32(sourceApplicationPID),
 	}
+}
+
+func restoreFrontmostApplication(pid int32, targetBundleID string) {
+	cBundleID := C.CString(targetBundleID)
+	defer C.free(unsafe.Pointer(cBundleID))
+	C.RestoreFrontmostApplication(C.int(pid), cBundleID)
 }
 
 //export TestURL

--- a/apps/finicky/src/main.h
+++ b/apps/finicky/src/main.h
@@ -9,10 +9,11 @@
 #include <syslog.h>
 #include <stdbool.h>
 
-extern void HandleURL(char *url, char *name, char *bundleId, char *path, char *windowTitle, bool openInBackground);
+extern void HandleURL(char *url, char *name, char *bundleId, char *path, char *windowTitle, bool openInBackground, int sourceApplicationPID);
 extern void QueueWindowDisplay(int launchedByUser);
 extern void ShowConfigWindow();
 extern char* GetCurrentConfigPath();
+extern void RestoreFrontmostApplication(int pid, const char *targetBundleID);
 
 #ifdef __OBJC__
 @interface BrowseAppDelegate: NSObject<NSApplicationDelegate>

--- a/apps/finicky/src/main.m
+++ b/apps/finicky/src/main.m
@@ -257,7 +257,7 @@
     NSString *urlString = [fileURL absoluteString];
 
     // Handle the file URL the same way we handle other URLs
-    HandleURL((char*)[urlString UTF8String], NULL, NULL, NULL, NULL, false);
+    HandleURL((char*)[urlString UTF8String], NULL, NULL, NULL, NULL, false, 0);
 
     return true;
 }
@@ -276,6 +276,7 @@
     self.receivedURL = true;
 
     NSRunningApplication *frontApp = [[NSWorkspace sharedWorkspace] frontmostApplication];
+    int sourceApplicationPID = [frontApp processIdentifier];
 
     // Assume Finicky is in front if we are not keeping running, since there's no good way
     // to detect if Finicky was launched in the background
@@ -284,6 +285,7 @@
     char *windowTitle = NULL;
 
     if (application) {
+        sourceApplicationPID = [application processIdentifier];
         NSString *appName = [application localizedName];
         NSString *appBundleID = [application bundleIdentifier];
         NSString *appPath = [[application bundleURL] path];
@@ -314,7 +316,7 @@
     }
 
     // If Finicky isn't frontmost, we take that to mean that the browser should, by default, be opened in the background
-    HandleURL((char*)url, (char*)name, (char*)bundleId, (char*)path, windowTitle, !finickyIsInFront);
+    HandleURL((char*)url, (char*)name, (char*)bundleId, (char*)path, windowTitle, !finickyIsInFront, sourceApplicationPID);
     free(windowTitle);
 }
 
@@ -332,8 +334,53 @@
         return false;
     }
 
-    HandleURL((char*)[[url absoluteString] UTF8String], NULL, NULL, NULL, NULL, false);
+    HandleURL((char*)[[url absoluteString] UTF8String], NULL, NULL, NULL, NULL, false, 0);
     return true;
+}
+
+void RestoreFrontmostApplication(int pid, const char *targetBundleID) {
+    if (pid <= 0 || targetBundleID == NULL) {
+        return;
+    }
+
+    NSString *targetBundleIdentifier = [NSString stringWithUTF8String:targetBundleID];
+    if (targetBundleIdentifier.length == 0) {
+        return;
+    }
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        NSRunningApplication *sourceApplication = [NSRunningApplication runningApplicationWithProcessIdentifier:pid];
+        if (!sourceApplication || sourceApplication.terminated || [sourceApplication.bundleIdentifier isEqualToString:targetBundleIdentifier]) {
+            return;
+        }
+
+        void (^restoreSourceApplication)(void) = ^{
+            if (!sourceApplication.terminated) {
+                [sourceApplication activateWithOptions:0];
+            }
+        };
+
+        NSRunningApplication *frontmostApplication = [NSWorkspace sharedWorkspace].frontmostApplication;
+        if ([frontmostApplication.bundleIdentifier isEqualToString:targetBundleIdentifier]) {
+            restoreSourceApplication();
+            return;
+        }
+
+        NSNotificationCenter *workspaceNotificationCenter = [NSWorkspace sharedWorkspace].notificationCenter;
+        __block id activationObserver = [workspaceNotificationCenter addObserverForName:NSWorkspaceDidActivateApplicationNotification object:nil queue:[NSOperationQueue mainQueue] usingBlock:^(NSNotification *notification) {
+            NSRunningApplication *activatedApplication = notification.userInfo[NSWorkspaceApplicationKey];
+            if ([activatedApplication.bundleIdentifier isEqualToString:targetBundleIdentifier]) {
+                restoreSourceApplication();
+            }
+        }];
+
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            if (activationObserver) {
+                [workspaceNotificationCenter removeObserver:activationObserver];
+                activationObserver = nil;
+            }
+        });
+    });
 }
 
 - (void)application:(NSApplication *)application didFailToContinueUserActivityWithType:(NSString *)userActivityType error:(NSError *)error {

--- a/packages/finicky-ui/src/pages/StartPage.svelte
+++ b/packages/finicky-ui/src/pages/StartPage.svelte
@@ -54,6 +54,9 @@
   // flags, not defaultBrowser/defaultProfile values above.
   $: defaultBrowserIsCustom = defaultBrowser !== "" && !installedBrowsers.includes(defaultBrowser);
   $: defaultProfileIsCustom = defaultProfile !== "" && !(profilesByBrowser[defaultBrowser] ?? []).includes(defaultProfile);
+  $: if (defaultBrowser && profilesByBrowser[defaultBrowser] === undefined) {
+    window.finicky.sendMessage({ type: "getBrowserProfiles", browser: defaultBrowser });
+  }
 
   function save() {
     if (isJSConfig) return;


### PR DESCRIPTION
## Summary
- Start the selected browser profile through its bundle executable instead of forwarding arguments through Launch Services.
- Return an error when a requested profile cannot be resolved.
- Preserve background link behavior by restoring the source application after the selected browser activates.
- Add profile-name, profile-directory, and application-path coverage plus a verification procedure.

## Validation
- `go test ./... -count=1`
- `go test -race ./browser -count=1`
- `go vet ./...`
- Tart: verified the opened Chrome tab reports the selected Profile Path in `chrome://version`, and verified source-app focus restoration three times.

Related to #491.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Browser launches support selecting profiles by name or profile directory.
  * Background launches restore the previously active application afterward.
  * Added support for the Ego Lite browser and improved browser detection.
  * Browser profiles load automatically when a default browser is selected.
* **Bug Fixes**
  * Invalid or unavailable requested profiles now produce a clear error.
  * Missing default configuration files no longer prevent fallback to JSON rules.
* **Documentation**
  * Added instructions for verifying Chrome profile routing and confirming the active profile path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->